### PR TITLE
Allow testing for differences in JSON structures.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,15 +59,15 @@ For example
 			
 Results in
 
-    java.lang.AssertionError: JSON documents are different:
-    Different keys found in node "". Expected [root2, root3, test], got [root4, test].
-    Different value found in node "test[0]". Expected 1, got 5.
-    Different values found in node "test[1]". Expected '2', got 'false'.
-    Different keys found in node "test[2]". Expected [child], got [child, child2].
-    Different value found in node "test[2].child.value1". Expected 1, got 5.
-    Different values found in node "test[2].child.value2". Expected 'true', got '"true"'.
-    Different keys found in node "test[2].child.value4". Expected [leaf], got [leaf2].
-
+	JSON documents have different structures:
+	Different keys found in node "". Expected [root2, root3, test], got [root4, test].
+	Different keys found in node "test[2]". Expected [child], got [child, child2].
+	Different keys found in node "test[2].child.value4". Expected [leaf], got [leaf2].
+	JSON documents have different values:
+	Different value found in node "test[0]". Expected 1, got 5.
+	Different values found in node "test[1]". Expected '2', got 'false'.
+	Different value found in node "test[2].child.value1". Expected 1, got 5.
+	Different values found in node "test[2].child.value2". Expected 'true', got '"true"'.
 
 
 Maven dependency

--- a/src/main/java/net/javacrumbs/jsonunit/JsonAssert.java
+++ b/src/main/java/net/javacrumbs/jsonunit/JsonAssert.java
@@ -23,27 +23,27 @@ import org.codehaus.jackson.JsonNode;
 import org.codehaus.jackson.map.ObjectMapper;
 
 /**
- * Assertions for comparing JSON. The comparison ignores whitespaces and order of nodes. 
+ * Assertions for comparing JSON. The comparison ignores whitespaces and order of nodes.
  * @author Lukas Krecan
  *
  */
  public class JsonAssert {
-	
+
 	private static final ObjectMapper MAPPER = new ObjectMapper();
-	
+
 	private JsonAssert(){
 		//nothing
 	}
-	
+
 	/**
-	 * Compares to JSON documents. Throws {@link AssertionError} if they are different.
+	 * Compares two JSON documents. Throws {@link AssertionError} if they are different.
 	 * @param expected
 	 * @param actual
 	 */
 	public static void  assertJsonEquals(String expected, String actual) {
 		assertJsonEquals(new StringReader(expected), new StringReader(actual));
 	}
-	
+
 	/**
 	 * Compares to JSON documents. Throws {@link AssertionError} if they are different.
 	 * @param expected
@@ -63,7 +63,7 @@ import org.codehaus.jackson.map.ObjectMapper;
 	public static void assertJsonEquals(JsonNode expectedNode, JsonNode actualNode) {
 		assertJsonPartEquals(expectedNode, actualNode, "");
 	}
-	
+
 	/**
 	 * Compares part of the JSON. Path has this format "root.array[0].value".
 	 * @param expected
@@ -88,7 +88,7 @@ import org.codehaus.jackson.map.ObjectMapper;
 		JsonNode fullJsonNode = readValue(fullJson, "fullJson");
 		assertJsonPartEquals(expectedNode, fullJsonNode, path);
 	}
-	
+
 	/**
 	 * Compares part of the JSON. Path has this format "root.array[0].value".
 	 * @param expected
@@ -99,7 +99,75 @@ import org.codehaus.jackson.map.ObjectMapper;
 		assertJsonPartEquals(new StringReader(expected), new StringReader(fullJson), path);
 	}
 
-	
+
+	/**
+	 * Compares structures of two JSON documents.
+	 * Throws {@link AssertionError} if they are different.
+	 * @param expected
+	 * @param actual
+	 */
+	public static void  assertJsonStructureEquals(String expected, String actual) {
+		assertJsonStructureEquals(new StringReader(expected), new StringReader(actual));
+	}
+
+	/**
+	 * Compares structures of two JSON documents.
+	 * Throws {@link AssertionError} if they are different.
+	 * @param expected
+	 * @param actual
+	 */
+	public static void  assertJsonStructureEquals(Reader expected, Reader actual) {
+		JsonNode expectedNode = readValue(expected, "expected");
+		JsonNode actualNode = readValue(actual, "actual");
+		assertJsonStructureEquals(expectedNode, actualNode);
+	}
+
+	/**
+	 * Compares structures of two JSON documents.
+	 * Throws {@link AssertionError} if they are different.
+	 * @param expectedNode
+	 * @param actualNode
+	 */
+	public static void assertJsonStructureEquals(JsonNode expectedNode, JsonNode actualNode) {
+		assertJsonStructurePartEquals(expectedNode, actualNode, "");
+	}
+
+	/**
+	 * Compares structure of part of the JSON. Path has this format "root.array[0].value".
+	 * @param expected
+	 * @param fullJson
+	 * @param path
+	 */
+	public static void assertJsonStructurePartEquals(JsonNode expected, JsonNode fullJson, String path) {
+		Diff diff = new Diff(expected, fullJson, path);
+		if (!diff.similarStructure()) {
+			doFail(diff.structureDifferences());
+		}
+	}
+
+	/**
+	 * Compares structure of part of the JSON. Path has this format "root.array[0].value".
+	 * @param expected
+	 * @param fullJson
+	 * @param path
+	 */
+	public static void assertJsonStructurePartEquals(Reader expected, Reader fullJson, String path) {
+		JsonNode expectedNode = readValue(expected, "expected");
+		JsonNode fullJsonNode = readValue(fullJson, "fullJson");
+		assertJsonStructurePartEquals(expectedNode, fullJsonNode, path);
+	}
+
+	/**
+	 * Compares structure of part of the JSON. Path has this format "root.array[0].value".
+	 * @param expected
+	 * @param fullJson
+	 * @param path
+	 */
+	public static void assertJsonStructurePartEquals(String expected, String fullJson, String path) {
+		assertJsonStructurePartEquals(new StringReader(expected), new StringReader(fullJson), path);
+	}
+
+
 	private static JsonNode readValue(Reader value, String label) {
 		try {
 			return MAPPER.readTree(value);
@@ -113,6 +181,6 @@ import org.codehaus.jackson.map.ObjectMapper;
 	private static void doFail(String diffMessage) {
 		throw new AssertionError(diffMessage);
 	}
-	
-	
+
+
 }

--- a/src/main/java/net/javacrumbs/jsonunit/differences/AbstractDifferences.java
+++ b/src/main/java/net/javacrumbs/jsonunit/differences/AbstractDifferences.java
@@ -1,0 +1,40 @@
+package net.javacrumbs.jsonunit.differences;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public abstract class AbstractDifferences implements Differences {
+
+	private String differenceType;
+	private List<String> messages = new ArrayList<String>();
+
+	protected AbstractDifferences(String differenceType) {
+		this.differenceType = differenceType;
+	}
+
+	public String getDifferenceType() {
+		return differenceType;
+	}
+
+	public void add(String message, Object... args) {
+		add(String.format(message, args));
+	}
+
+	public void add(String message) {
+		messages.add(message);
+	}
+
+	public boolean isEmpty() {
+		return messages.isEmpty();
+	}
+
+	public void appendDifferences(StringBuilder builder) {
+		if ( ! messages.isEmpty()) {
+			builder.append("JSON documents have different " + getDifferenceType() + ":\n");
+			for (String message : messages) {
+				builder.append(message).append("\n");
+			}
+	    }
+	}
+
+}

--- a/src/main/java/net/javacrumbs/jsonunit/differences/Differences.java
+++ b/src/main/java/net/javacrumbs/jsonunit/differences/Differences.java
@@ -1,0 +1,10 @@
+package net.javacrumbs.jsonunit.differences;
+
+public interface Differences {
+
+	String getDifferenceType();
+	void add(String message, Object... args);
+	void add(String message);
+	boolean isEmpty();
+	void appendDifferences(StringBuilder builder);
+}

--- a/src/main/java/net/javacrumbs/jsonunit/differences/StructureDifferences.java
+++ b/src/main/java/net/javacrumbs/jsonunit/differences/StructureDifferences.java
@@ -1,0 +1,9 @@
+package net.javacrumbs.jsonunit.differences;
+
+public class StructureDifferences extends AbstractDifferences {
+
+	public StructureDifferences() {
+		super("structures");
+	}
+
+}

--- a/src/main/java/net/javacrumbs/jsonunit/differences/ValueDifferences.java
+++ b/src/main/java/net/javacrumbs/jsonunit/differences/ValueDifferences.java
@@ -1,0 +1,9 @@
+package net.javacrumbs.jsonunit.differences;
+
+public class ValueDifferences extends AbstractDifferences {
+
+	public ValueDifferences() {
+		super("values");
+	}
+
+}

--- a/src/test/java/net/javacrumbs/jsonunit/JsonAssertTest.java
+++ b/src/test/java/net/javacrumbs/jsonunit/JsonAssertTest.java
@@ -26,7 +26,7 @@ import org.codehaus.jackson.node.ObjectNode;
 import org.junit.Test;
 
 public class JsonAssertTest {
-	
+
 	private static final ObjectMapper MAPPER = new ObjectMapper();
 
 	@Test
@@ -45,7 +45,7 @@ public class JsonAssertTest {
 			assertJsonEquals("[{\"test\":1}, {\"test\":2}]", "[{\n\"test\": 1\n}, {\"test\": 4}]");
 			fail("Exception expected");
 		} catch (AssertionError e) {
-			assertEquals("JSON documents are different:\nDifferent value found in node \"[1].test\". Expected 2, got 4.\n", e.getMessage());
+			assertEquals("JSON documents have different values:\nDifferent value found in node \"[1].test\". Expected 2, got 4.\n", e.getMessage());
 		}
 	}
 	@Test
@@ -58,7 +58,7 @@ public class JsonAssertTest {
 			assertJsonEquals("1", "\n2\n");
 			fail("Exception expected");
 		} catch (AssertionError e) {
-			assertEquals("JSON documents are different:\nDifferent value found in node \"\". Expected 1, got 2.\n", e.getMessage());
+			assertEquals("JSON documents have different values:\nDifferent value found in node \"\". Expected 1, got 2.\n", e.getMessage());
 		}
 	}
 
@@ -72,22 +72,22 @@ public class JsonAssertTest {
 			assertJsonEquals(MAPPER.readValue("{\"test\":1}", ObjectNode.class) , MAPPER.readValue("{\"test\": 2}", ObjectNode.class));
 			fail("Exception expected");
 		} catch (AssertionError e) {
-			assertEquals("JSON documents are different:\nDifferent value found in node \"test\". Expected 1, got 2.\n", e.getMessage());
+			assertEquals("JSON documents have different values:\nDifferent value found in node \"test\". Expected 1, got 2.\n", e.getMessage());
 		}
 	}
-	
+
 	@Test(expected=IllegalArgumentException.class)
 	public void testInvalidJsonActual() {
 		assertJsonEquals("{\"test\":1}", "{\n\"foo\": 1\n");
 	}
-	
+
 	@Test
 	public void testObjectName() {
 		try {
 			assertJsonEquals("{\"test\":1}", "{\n\"foo\": 1\n}");
 			fail("Exception expected");
 		} catch (AssertionError e) {
-			assertEquals("JSON documents are different:\nDifferent keys found in node \"\". Expected [test], got [foo].\n", e.getMessage());
+			assertEquals("JSON documents have different structures:\nDifferent keys found in node \"\". Expected [test], got [foo].\n", e.getMessage());
 		}
 	}
 
@@ -95,24 +95,24 @@ public class JsonAssertTest {
 	public void testNullOk() {
 		assertJsonEquals("{\"test\":null}", "{\n\"test\": null\n}");
 	}
-	
+
 	@Test
 	public void testNullFail() {
 		try {
 			assertJsonEquals("{\"test\":null}", "{\n\"test\": 1\n}");
 			fail("Exception expected");
 		} catch (AssertionError e) {
-			assertEquals("JSON documents are different:\nDifferent values found in node \"test\". Expected 'null', got '1'.\n", e.getMessage());
+			assertEquals("JSON documents have different values:\nDifferent values found in node \"test\". Expected 'null', got '1'.\n", e.getMessage());
 		}
 	}
-	
+
 	@Test
 	public void testExtraRootKey() {
 		try {
 			assertJsonEquals("{\"test\":1}", "{\n\"test\": 1\n, \"foo\": 2}");
 			fail("Exception expected");
 		} catch (AssertionError e) {
-			assertEquals("JSON documents are different:\nDifferent keys found in node \"\". Expected [test], got [foo, test].\n", e.getMessage());
+			assertEquals("JSON documents have different structures:\nDifferent keys found in node \"\". Expected [test], got [foo, test].\n", e.getMessage());
 		}
 	}
 
@@ -122,30 +122,30 @@ public class JsonAssertTest {
 			assertJsonEquals("{\"test\":1, \"foo\": 2}", "{\n\"test\": 1\n}");
 			fail("Exception expected");
 		} catch (AssertionError e) {
-			assertEquals("JSON documents are different:\nDifferent keys found in node \"\". Expected [foo, test], got [test].\n", e.getMessage());
+			assertEquals("JSON documents have different structures:\nDifferent keys found in node \"\". Expected [foo, test], got [test].\n", e.getMessage());
 		}
 	}
-	
+
 	@Test
 	public void testDifferentNumericValue() {
 		try {
 			assertJsonEquals("{\"test\":1}", "{\n\"test\": 2\n}");
 			fail("Exception expected");
 		} catch (AssertionError e) {
-			assertEquals("JSON documents are different:\nDifferent value found in node \"test\". Expected 1, got 2.\n", e.getMessage());
+			assertEquals("JSON documents have different values:\nDifferent value found in node \"test\". Expected 1, got 2.\n", e.getMessage());
 		}
 	}
-	
+
 	@Test
 	public void testDifferentBooleanValue() {
 		try {
 			assertJsonEquals("{\"test\":true}", "{\n\"test\": false\n}");
 			fail("Exception expected");
 		} catch (AssertionError e) {
-			assertEquals("JSON documents are different:\nDifferent value found in node \"test\". Expected true, got false.\n", e.getMessage());
+			assertEquals("JSON documents have different values:\nDifferent value found in node \"test\". Expected true, got false.\n", e.getMessage());
 		}
 	}
-	
+
 	@Test
 	public void testSameArrayValue() {
 		assertJsonEquals("{\"test\":[1, 2, 3]}", "{\n\"test\": [1, 2, 3]\n}");
@@ -157,7 +157,7 @@ public class JsonAssertTest {
 			assertJsonEquals("{\"test\":[1, 2, 3]}", "{\n\"test\": [1, 2]\n}");
 			fail("Exception expected");
 		} catch (AssertionError e) {
-			assertEquals("JSON documents are different:\nArray \"test\" has different length. Expected 3, got 2.\n", e.getMessage());
+			assertEquals("JSON documents have different structures:\nArray \"test\" has different length. Expected 3, got 2.\n", e.getMessage());
 		}
 	}
 
@@ -167,7 +167,7 @@ public class JsonAssertTest {
 			assertJsonEquals("{\"test\":[1, 2, 3]}", "{\n\"test\": [1, 2, 5]\n}");
 			fail("Exception expected");
 		} catch (AssertionError e) {
-			assertEquals("JSON documents are different:\nDifferent value found in node \"test[2]\". Expected 3, got 5.\n", e.getMessage());
+			assertEquals("JSON documents have different values:\nDifferent value found in node \"test[2]\". Expected 3, got 5.\n", e.getMessage());
 		}
 	}
 	@Test
@@ -176,90 +176,92 @@ public class JsonAssertTest {
 			assertJsonEquals("{\"test\":[1, 2, 3]}", "{\n\"test\": [1, false, 3]\n}");
 			fail("Exception expected");
 		} catch (AssertionError e) {
-			assertEquals("JSON documents are different:\nDifferent values found in node \"test[1]\". Expected '2', got 'false'.\n", e.getMessage());
+			assertEquals("JSON documents have different values:\nDifferent values found in node \"test[1]\". Expected '2', got 'false'.\n", e.getMessage());
 		}
 	}
-	
+
 	@Test
 	public void testComplexOk() {
-			assertJsonEquals("{\"test\":[1, 2, {\"child\":{\"value1\":1, \"value2\":true, \"value3\": \"test\", \"value4\":{\"leaf\":5}}}], \"root2\": false}", 
+			assertJsonEquals("{\"test\":[1, 2, {\"child\":{\"value1\":1, \"value2\":true, \"value3\": \"test\", \"value4\":{\"leaf\":5}}}], \"root2\": false}",
 					"{\"test\":[1, 2, {\"child\":{\"value1\":1, \"value2\":true, \"value3\": \"test\", \"value4\":{\"leaf\":5}}}], \"root2\": false}");
-		
+
 	}
 
 	@Test
 	public void testComplexErrors() {
 		try {
-			assertJsonEquals("{\n" + 
-					"   \"test\":[\n" + 
-					"      1,\n" + 
-					"      2,\n" + 
-					"      {\n" + 
-					"         \"child\":{\n" + 
-					"            \"value1\":1,\n" + 
-					"            \"value2\":true,\n" + 
-					"            \"value3\":\"test\",\n" + 
-					"            \"value4\":{\n" + 
-					"               \"leaf\":5\n" + 
-					"            }\n" + 
-					"         }\n" + 
-					"      }\n" + 
-					"   ],\n" + 
-					"   \"root2\":false,\n" + 
-					"   \"root3\":1\n" + 
-					"}", 
-				"{\n" + 
-				"   \"test\":[\n" + 
-				"      5,\n" + 
-				"      false,\n" + 
-				"      {\n" + 
-				"         \"child\":{\n" + 
-				"            \"value1\":5,\n" + 
-				"            \"value2\":\"true\",\n" + 
-				"            \"value3\":\"test\",\n" + 
-				"            \"value4\":{\n" + 
-				"               \"leaf2\":5\n" + 
-				"            }\n" + 
-				"         },\n" + 
-				"         \"child2\":{\n" + 
-				"\n" + 
-				"         }\n" + 
-				"      }\n" + 
-				"   ],\n" + 
-				"   \"root4\":\"bar\"\n" + 
+			assertJsonEquals("{\n" +
+					"   \"test\":[\n" +
+					"      1,\n" +
+					"      2,\n" +
+					"      {\n" +
+					"         \"child\":{\n" +
+					"            \"value1\":1,\n" +
+					"            \"value2\":true,\n" +
+					"            \"value3\":\"test\",\n" +
+					"            \"value4\":{\n" +
+					"               \"leaf\":5\n" +
+					"            }\n" +
+					"         }\n" +
+					"      }\n" +
+					"   ],\n" +
+					"   \"root2\":false,\n" +
+					"   \"root3\":1\n" +
+					"}",
+				"{\n" +
+				"   \"test\":[\n" +
+				"      5,\n" +
+				"      false,\n" +
+				"      {\n" +
+				"         \"child\":{\n" +
+				"            \"value1\":5,\n" +
+				"            \"value2\":\"true\",\n" +
+				"            \"value3\":\"test\",\n" +
+				"            \"value4\":{\n" +
+				"               \"leaf2\":5\n" +
+				"            }\n" +
+				"         },\n" +
+				"         \"child2\":{\n" +
+				"\n" +
+				"         }\n" +
+				"      }\n" +
+				"   ],\n" +
+				"   \"root4\":\"bar\"\n" +
 				"}");
 			fail("Exception expected");
 		} catch (AssertionError e) {
-			assertEquals("JSON documents are different:\n" + 
-					"Different keys found in node \"\". Expected [root2, root3, test], got [root4, test].\n" + 
-					"Different value found in node \"test[0]\". Expected 1, got 5.\n" + 
-					"Different values found in node \"test[1]\". Expected '2', got 'false'.\n" + 
-					"Different keys found in node \"test[2]\". Expected [child], got [child, child2].\n" + 
-					"Different value found in node \"test[2].child.value1\". Expected 1, got 5.\n" + 
-					"Different values found in node \"test[2].child.value2\". Expected 'true', got '\"true\"'.\n" + 
-					"Different keys found in node \"test[2].child.value4\". Expected [leaf], got [leaf2].\n"  
+			assertEquals(
+					"JSON documents have different structures:\n" +
+							"Different keys found in node \"\". Expected [root2, root3, test], got [root4, test].\n" +
+							"Different keys found in node \"test[2]\". Expected [child], got [child, child2].\n" +
+							"Different keys found in node \"test[2].child.value4\". Expected [leaf], got [leaf2].\n" +
+							"JSON documents have different values:\n" +
+							"Different value found in node \"test[0]\". Expected 1, got 5.\n" +
+							"Different values found in node \"test[1]\". Expected '2', got 'false'.\n" +
+							"Different value found in node \"test[2].child.value1\". Expected 1, got 5.\n" +
+							"Different values found in node \"test[2].child.value2\". Expected 'true', got '\"true\"'.\n"
 					, e.getMessage());
 		}
-		
+
 	}
-	
+
 	@Test
 	public void testDifferentNumericTypes() {
 		try {
 			assertJsonEquals("{\"test\":1}", "{\n\"test\": 1.0\n}");
 			fail("Exception expected");
 		} catch (AssertionError e) {
-			assertEquals("JSON documents are different:\nDifferent value found in node \"test\". Expected 1, got 1.0.\n", e.getMessage());
+			assertEquals("JSON documents have different values:\nDifferent value found in node \"test\". Expected 1, got 1.0.\n", e.getMessage());
 		}
 	}
-	
+
 	@Test
 	public void testDifferentType() {
 		try {
 			assertJsonEquals("{\"test\":1}", "{\n\"test\": \"something\"\n}");
 			fail("Exception expected");
 		} catch (AssertionError e) {
-			assertEquals("JSON documents are different:\nDifferent values found in node \"test\". Expected '1', got '\"something\"'.\n", e.getMessage());
+			assertEquals("JSON documents have different values:\nDifferent values found in node \"test\". Expected '1', got '\"something\"'.\n", e.getMessage());
 		}
 	}
 
@@ -269,7 +271,7 @@ public class JsonAssertTest {
 			assertJsonEquals("{\"test\":{}}", "{\n\"test\": \"something\"\n}");
 			fail("Exception expected");
 		} catch (AssertionError e) {
-			assertEquals("JSON documents are different:\nDifferent values found in node \"test\". Expected '{}', got '\"something\"'.\n", e.getMessage());
+			assertEquals("JSON documents have different values:\nDifferent values found in node \"test\". Expected '{}', got '\"something\"'.\n", e.getMessage());
 		}
 	}
 	@Test
@@ -281,49 +283,64 @@ public class JsonAssertTest {
 	public void testAssertPartOk() {
 		assertJsonPartEquals("1", "{\"test\":{\"value\":1}}", "test.value");
 	}
-	
+
 	@Test
 	public void testAssertPart() {
 		try {
 			assertJsonPartEquals("2", "{\"test\":{\"value\":1}}", "test.value");
 			fail("Exception expected");
 		} catch (AssertionError e) {
-			assertEquals("JSON documents are different:\nDifferent value found in node \"test.value\". Expected 2, got 1.\n", e.getMessage());
+			assertEquals("JSON documents have different values:\nDifferent value found in node \"test.value\". Expected 2, got 1.\n", e.getMessage());
 		}
 	}
 
 	@Test
-	public void testAssertPartSomplex() {
+	public void testAssertPartComplex() {
 		try {
 			assertJsonPartEquals("{\"value\":2}", "{\"test\":{\"value\":1}}", "test");
 			fail("Exception expected");
 		} catch (AssertionError e) {
-			assertEquals("JSON documents are different:\nDifferent value found in node \"test.value\". Expected 2, got 1.\n", e.getMessage());
+			assertEquals("JSON documents have different values:\nDifferent value found in node \"test.value\". Expected 2, got 1.\n", e.getMessage());
 		}
 	}
-	
+
 	@Test
 	public void testAssertPartArrayOk() {
 		assertJsonPartEquals("2", "{\"test\":[{\"value\":1},{\"value\":2}]}", "test[1].value");
 	}
-	
+
 	@Test
 	public void testAssertPartArray() {
 		try {
 			assertJsonPartEquals("3", "{\"test\":[{\"value\":1},{\"value\":2}]}", "test[1].value");
 			fail("Exception expected");
 		} catch (AssertionError e) {
-			assertEquals("JSON documents are different:\nDifferent value found in node \"test[1].value\". Expected 3, got 2.\n", e.getMessage());
+			assertEquals("JSON documents have different values:\nDifferent value found in node \"test[1].value\". Expected 3, got 2.\n", e.getMessage());
 		}
 	}
 
 	@Test
-	public void testAssertPartNonexistiong() {
+	public void testAssertPartNonexisting() {
 		try {
 			assertJsonPartEquals("2", "{\"test\":{\"value\":1}}", "test.bogus");
 			fail("Exception expected");
 		} catch (AssertionError e) {
-			assertEquals("JSON documents are different:\nNo value found in path \"test.bogus\".\n", e.getMessage());
+			assertEquals("JSON documents have different structures:\nMissing node in path \"test.bogus\".\n", e.getMessage());
+		}
+	}
+
+	@Test
+	public void testAssertStructureEquals() {
+		assertJsonStructureEquals("[{\"test\":1}, {\"test\":2}]", "[{\n\"test\": 1\n}, {\"test\": 4}]");
+	}
+
+	@Test
+	public void testAssertStructureDiffers() {
+		try {
+			assertJsonStructureEquals("[{\"test\":1}, {\"test\":2}]", "[{\n\"test\": 1\n}, {\"TEST\": 4}]");
+			fail("Exception expected");
+		} catch (AssertionError e) {
+			assertEquals("JSON documents have different structures:\nDifferent keys found in node \"[1]\". Expected [test], got [TEST].\n", e.getMessage());
 		}
 	}
 }


### PR DESCRIPTION
Classes in net.javacrumbs.jsonunit.differences added to
collect and report value and structure differences.

I really appreciate your JsonUnit and plan to use it at work.
I have extended the package to allow it to ignore value differences
within a JSON document and just report structural differences.
