### PR TITLE
Added optinal tolerance value for numeric comparisons

### DIFF
--- a/json-unit-core/src/main/java/net/javacrumbs/jsonunit/core/internal/Diff.java
+++ b/json-unit-core/src/main/java/net/javacrumbs/jsonunit/core/internal/Diff.java
@@ -52,6 +52,7 @@ public class Diff {
     private final Differences structureDifferences = new Differences("structures");
     private final Differences valueDifferences = new Differences("values");
     private final String startPath;
+    private final Double tolerance;
     private boolean compared = false;
     private final String ignorePlaceholder;
 
@@ -60,20 +61,33 @@ public class Diff {
 
     private enum NodeType {OBJECT, ARRAY, STRING, NUMBER, BOOLEAN, NULL}
 
+    public Diff(JsonNode expected, JsonNode actual, String startPath, String ignorePlaceholder,Double tolerance) {
+        super();
+        this.expectedRoot = expected;
+        this.actualRoot = actual;
+        this.startPath = startPath;
+        this.ignorePlaceholder = ignorePlaceholder;
+        this.tolerance=tolerance;
+    }
+
     public Diff(JsonNode expected, JsonNode actual, String startPath, String ignorePlaceholder) {
         super();
         this.expectedRoot = expected;
         this.actualRoot = actual;
         this.startPath = startPath;
         this.ignorePlaceholder = ignorePlaceholder;
+        this.tolerance=null;
     }
 
+    public static Diff create(Object expected, Object actual, String actualName, String startPath, String ignorePlaceholder,Double tolerance) {
+        return new Diff(convertToJson(quoteIfNeeded(expected), "expected"), convertToJson(actual, actualName), startPath, ignorePlaceholder,tolerance);
+    }
     public static Diff create(Object expected, Object actual, String actualName, String startPath, String ignorePlaceholder) {
-        return new Diff(convertToJson(quoteIfNeeded(expected), "expected"), convertToJson(actual, actualName), startPath, ignorePlaceholder);
+        return create(expected,actual,actualName,startPath,ignorePlaceholder,null);
     }
 
 
-    private void compare() {
+        private void compare() {
         if (!compared) {
             JsonNode part = getStartNode(actualRoot, startPath);
             if (part.isMissingNode()) {
@@ -200,7 +214,14 @@ public class Diff {
                     compareValues(expectedNode.asText(), actualNode.asText(), fieldPath);
                     break;
                 case NUMBER:
-                    compareValues(expectedNode.numberValue(), actualNode.numberValue(), fieldPath);
+                    if(tolerance != null) {
+                        //Note this is not the most accurate implementation of this, I wanted to keep this as minimal as possible
+                        Double diff=Math.abs(expectedNode.numberValue().doubleValue()-actualNode.numberValue().doubleValue());
+                        if(diff>tolerance)
+                            valueDifferenceFound("Different value found in node \"%s\". Expected %s, got %s, difference is %s tolerance is %s", fieldPath, quoteTextValue(expectedNode.numberValue()),quoteTextValue(actualNode.numberValue()),diff.toString(),tolerance.toString());
+                    }
+                    else
+                        compareValues(expectedNode.numberValue(), actualNode.numberValue(), fieldPath);
                     break;
                 case BOOLEAN:
                     compareValues(expectedNode.asBoolean(), actualNode.asBoolean(), fieldPath);
@@ -216,6 +237,8 @@ public class Diff {
 
 
     private void compareValues(Object expectedValue, Object actualValue, String path) {
+
+
         if (!expectedValue.equals(actualValue)) {
             valueDifferenceFound("Different value found in node \"%s\". Expected %s, got %s.", path, quoteTextValue(expectedValue), quoteTextValue(actualValue));
         }

--- a/json-unit/src/main/java/net/javacrumbs/jsonunit/JsonAssert.java
+++ b/json-unit/src/main/java/net/javacrumbs/jsonunit/JsonAssert.java
@@ -51,9 +51,26 @@ public class JsonAssert {
      * @param actual
      */
     public static void assertJsonEquals(Object expected, Object actual) {
-        assertJsonPartEquals(expected, actual, "");
+        assertJsonPartEquals(expected, actual, "",null);
     }
 
+    /**
+     * Compares two JSON documents, making sure all Number values are within the given tolerance. Throws {@link AssertionError} if they are different.
+     * @param expected
+     * @param actual
+     * @param tolerance
+     */
+    public static void assertJsonEquals(Object expected, Object actual, Double tolerance) {
+        assertJsonPartEquals(expected, actual, "",tolerance);
+
+    }
+
+    public static void assertJsonPartEquals(Object expected, Object fullJson, String path,Double tolerance) {
+        Diff diff = create(expected, fullJson, FULL_JSON, path, ignorePlaceholder,tolerance);
+        if (!diff.similar()) {
+            doFail(diff.toString());
+        }
+    }
     /**
      * Compares part of the JSON. Path has this format "root.array[0].value".
      *
@@ -62,10 +79,7 @@ public class JsonAssert {
      * @param path
      */
     public static void assertJsonPartEquals(Object expected, Object fullJson, String path) {
-        Diff diff = create(expected, fullJson, FULL_JSON, path, ignorePlaceholder);
-        if (!diff.similar()) {
-            doFail(diff.toString());
-        }
+        assertJsonPartEquals(expected,fullJson,path,null);
     }
 
     /**
@@ -76,7 +90,7 @@ public class JsonAssert {
      * @param actual
      */
     public static void assertJsonStructureEquals(Object expected, Object actual) {
-        Diff diff = create(expected, actual, ACTUAL, "", ignorePlaceholder);
+        Diff diff = create(expected, actual, ACTUAL, "", ignorePlaceholder,null);
         if (!diff.similarStructure()) {
             doFail(diff.structureDifferences());
         }
@@ -90,7 +104,7 @@ public class JsonAssert {
      * @param path
      */
     public static void assertJsonPartStructureEquals(Object expected, Object fullJson, String path) {
-        Diff diff = create(expected, fullJson, FULL_JSON, path, ignorePlaceholder);
+        Diff diff = create(expected, fullJson, FULL_JSON, path, ignorePlaceholder,null);
         if (!diff.similarStructure()) {
             doFail(diff.structureDifferences());
         }

--- a/json-unit/src/test/java/net/javacrumbs/jsonunit/JsonAssertTest.java
+++ b/json-unit/src/test/java/net/javacrumbs/jsonunit/JsonAssertTest.java
@@ -121,6 +121,36 @@ public class JsonAssertTest {
     }
 
     @Test
+    public void testNotEqualWhenToleranceNotSet() {
+        try {
+            assertJsonEquals("1", "\n1.0\n");
+            fail("Exception expected");
+        } catch (AssertionError e) {
+        }
+    }
+
+    @Test
+    public void testComparisonWhenWithinTolerance() {
+        assertJsonEquals("1", "\n1.009\n",0.01);
+    }
+
+    @Test
+    public void testComparisonWhenWithinToleranceNegative() {
+        assertJsonEquals("1", "\n0.9999\n",0.01);
+    }
+
+
+
+    @Test
+    public void testComparisonWhenOverTolerance() {
+        try {
+            assertJsonEquals("1", "\n1.1\n",0.1);
+            fail("Exception expected");
+        } catch (AssertionError e) {
+        }
+    }
+
+    @Test
     public void testNullOk() {
         assertJsonEquals("{\"test\":null}", "{\n\"test\": null\n}");
     }


### PR DESCRIPTION
The current implementation only does exact comparisons, there are certain situations(for example when different sources format floating point values differently) where you may want to add a tolerance to the numeric comparisons.  I added an optional tolerance parameter to the assertJsonEquals method(and of course method that method calls) that will return true if the two numeric values are within the given range.  I have added test cases that show my code works and I hope it can be incorporated into the main branch.

Thanks,

-Joel L. Tucci
