### PR TITLE
Fix OSGI Manifest headers after cleaning

### DIFF
--- a/json-unit-core/pom.xml
+++ b/json-unit-core/pom.xml
@@ -50,7 +50,10 @@
                         <Bundle-Name>${artifactId}</Bundle-Name>
                         <Bundle-SymbolicName>${symbolic.name}</Bundle-SymbolicName>
                         <Bundle-Description>${pom.description}</Bundle-Description>
-                        <Import-Package>*</Import-Package>
+                        <Import-Package>
+                            com.fasterxml.jackson.core;resolution:=optional,
+							*
+						</Import-Package>
                         <Export-Package>
                             net.javacrumbs.jsonunit.core,
                             net.javacrumbs.jsonunit.core.internal

--- a/json-unit-core/pom.xml
+++ b/json-unit-core/pom.xml
@@ -52,8 +52,8 @@
                         <Bundle-Description>${pom.description}</Bundle-Description>
                         <Import-Package>
                             com.fasterxml.jackson.core;resolution:=optional,
-							*
-						</Import-Package>
+                            *
+                        </Import-Package>
                         <Export-Package>
                             net.javacrumbs.jsonunit.core,
                             net.javacrumbs.jsonunit.core.internal

--- a/json-unit/pom.xml
+++ b/json-unit/pom.xml
@@ -37,10 +37,11 @@
 				<version>3.0.0</version>
 				<configuration>
 					<instructions>
-						<Bundle-Name>JsonUnit</Bundle-Name>
-						<Bundle-SymbolicName>net.javacrumbs.jsonunit</Bundle-SymbolicName>
-						<Export-Package>net.javacrumbs.jsonunit.*</Export-Package>
-						<Bundle-RequiredExecutionEnvironment>JavaSE-1.7</Bundle-RequiredExecutionEnvironment>
+						<Bundle-Name>${artifactId}</Bundle-Name>
+						<Bundle-SymbolicName>${symbolic.name}</Bundle-SymbolicName>
+						<Bundle-Description>${pom.description}</Bundle-Description>
+						<Export-Package>net.javacrumbs.jsonunit</Export-Package>
+						<Bundle-RequiredExecutionEnvironment></Bundle-RequiredExecutionEnvironment>
 						<_removeheaders>Bnd-LastModified</_removeheaders>
 					</instructions>
 				</configuration>


### PR DESCRIPTION
I have checked and fix build definition 
com.fasterxml.jackson.core;resolution:=optional was removed from import package during cleaning, it is important to keep it because JsonUnit use dynamic invocation to check if com.fasterxml.jackson.core.JsonGenerator class is available, so bnd is not able to automatically manage import for this class

I have also fixed json-unit artifact build