### PR TITLE
Fix some tests and uniformize failure expectation name

### DIFF
--- a/json-unit-spring/src/test/java/net/javacrumbs/jsonunit/spring/ExampleControllerTest.java
+++ b/json-unit-spring/src/test/java/net/javacrumbs/jsonunit/spring/ExampleControllerTest.java
@@ -62,7 +62,7 @@ public class ExampleControllerTest {
     public void isEqualToShouldFailIfDoesNotEqual() throws Exception {
         try {
             exec().andExpect(json().isEqualTo(CORRECT_JSON.replace("stringValue", "stringValue2")));
-            doFail();
+            failIfNoException();
         } catch (AssertionError e) {
             assertEquals(
                 "JSON documents are different:\n" +
@@ -75,7 +75,7 @@ public class ExampleControllerTest {
     public void isStringEqualToShouldFailOnNumber() throws Exception {
         try {
             exec().andExpect(json().node("result.array[0]").isStringEqualTo("1"));
-            doFail();
+            failIfNoException();
         } catch (AssertionError e) {
             assertEquals("Node \"result.array[0]\" is not a string. The actual value is '1'.", e.getMessage());
         }
@@ -90,7 +90,7 @@ public class ExampleControllerTest {
     public void isAbsentShouldFailIfNodeExists() throws Exception {
         try {
             exec().andExpect(json().node("result.string").isAbsent());
-            doFail();
+            failIfNoException();
         } catch (AssertionError e) {
             assertEquals("Node \"result.string\" is present.", e.getMessage());
         }
@@ -106,7 +106,7 @@ public class ExampleControllerTest {
     public void isPresentShouldFailIfNodeIsAbsent() throws Exception {
         try {
             exec().andExpect(json().node("result.string2").isPresent());
-            doFail();
+            failIfNoException();
         } catch (AssertionError e) {
             assertEquals("Node \"result.string2\" is missing.", e.getMessage());
         }
@@ -121,7 +121,7 @@ public class ExampleControllerTest {
     public void isArrayShouldFailOnNotArray() throws Exception {
         try {
             exec().andExpect(json().node("result.string").isArray());
-            doFail();
+            failIfNoException();
         } catch (AssertionError e) {
             assertEquals("Node \"result.string\" is not an array. The actual value is '\"stringValue\"'.", e.getMessage());
         }
@@ -131,7 +131,7 @@ public class ExampleControllerTest {
     public void isArrayShouldFailIfNotPresent() throws Exception {
         try {
             exec().andExpect(json().node("result.array2").isArray());
-            doFail();
+            failIfNoException();
         } catch (AssertionError e) {
             assertEquals("Node \"result.array2\" is missing.", e.getMessage());
         }
@@ -142,7 +142,7 @@ public class ExampleControllerTest {
     public void isObjectShouldFailOnArray() throws Exception {
         try {
             exec().andExpect(json().node("result.array").isObject());
-            doFail();
+            failIfNoException();
         } catch (AssertionError e) {
             assertEquals("Node \"result.array\" is not an object. The actual value is '[1,2,3]'.", e.getMessage());
         }
@@ -152,7 +152,7 @@ public class ExampleControllerTest {
     public void isStringShouldFailOnArray() throws Exception {
         try {
             exec().andExpect(json().node("result.array").isString());
-            doFail();
+            failIfNoException();
         } catch (AssertionError e) {
             assertEquals("Node \"result.array\" is not a string. The actual value is '[1,2,3]'.", e.getMessage());
         }
@@ -187,7 +187,7 @@ public class ExampleControllerTest {
     public void isNotEqualToShouldFailIfEquals() throws Exception {
         try {
             exec().andExpect(json().isNotEqualTo(CORRECT_JSON));
-            doFail();
+            failIfNoException();
         } catch (AssertionError e) {
             assertEquals(
                 "JSON is equal.", e.getMessage());
@@ -199,7 +199,7 @@ public class ExampleControllerTest {
         try {
             exec()
                 .andExpect(json().node("result.string").isEqualTo("stringValue2"));
-            doFail();
+            failIfNoException();
         } catch (AssertionError e) {
             assertEquals("JSON documents are different:\n" +
                     "Different value found in node \"result.string\". Expected \"stringValue2\", got \"stringValue\".\n",
@@ -216,7 +216,7 @@ public class ExampleControllerTest {
     public void intValueShouldFailIfDoesNotMatch() throws Exception {
         try {
             exec().andExpect(json().node("result.array").matches(everyItem(lessThanOrEqualTo(valueOf(2)))));
-            doFail();
+            failIfNoException();
         } catch (AssertionError e) {
             assertEquals("Node \"result.array\" does not match.\n" +
                     "Expected: every item is a value less than or equal to <2>\n" +
@@ -229,7 +229,7 @@ public class ExampleControllerTest {
         return this.mockMvc.perform(get("/sample").accept(MediaType.APPLICATION_JSON));
     }
 
-    private void doFail() {
+    private void failIfNoException() {
         fail("Exception expected");
     }
 

--- a/tests/test-base/src/main/java/net/javacrumbs/jsonunit/test/base/AbstractJsonAssertTest.java
+++ b/tests/test-base/src/main/java/net/javacrumbs/jsonunit/test/base/AbstractJsonAssertTest.java
@@ -80,6 +80,7 @@ public abstract class AbstractJsonAssertTest {
         try {
             JsonAssert.setTolerance(0.001);
             assertJsonEquals(1, "\"hi\"");
+            failIfNoException();
         } catch (AssertionError e) {
             assertEquals("JSON documents are different:\nDifferent value found in node \"\". Expected '1', got '\"hi\"'.\n", e.getMessage());
         }
@@ -682,6 +683,7 @@ public abstract class AbstractJsonAssertTest {
         JsonAssert.setOptions(IGNORING_VALUES);
         try {
             assertJsonEquals("{\"test\":{\"a\":1,\"b\":2,\"c\":3}}", "{\"test\":{\"a\":3,\"b\":\"2\",\"c\":1}}");
+            failIfNoException();
         } catch (AssertionError e) {
             assertEquals("JSON documents are different:\n" +
                 "Different value found in node \"test.b\". Expected '2', got '\"2\"'.\n", e.getMessage());
@@ -693,6 +695,7 @@ public abstract class AbstractJsonAssertTest {
         JsonAssert.setOptions(IGNORING_VALUES);
         try {
             assertJsonEquals("{\"test\":[{\"a\":1},{\"b\":2},{\"c\":3}]}", "{\"test\":[{\"a\":1},{\"b\":\"2\"},{\"c\":3}]}");
+            failIfNoException();
         } catch (AssertionError e) {
             assertEquals("JSON documents are different:\n" +
                 "Different value found in node \"test[1].b\". Expected '2', got '\"2\"'.\n", e.getMessage());

--- a/tests/test-base/src/main/java/net/javacrumbs/jsonunit/test/base/AbstractJsonAssertTest.java
+++ b/tests/test-base/src/main/java/net/javacrumbs/jsonunit/test/base/AbstractJsonAssertTest.java
@@ -36,6 +36,7 @@ import static net.javacrumbs.jsonunit.core.Option.IGNORING_ARRAY_ORDER;
 import static net.javacrumbs.jsonunit.core.Option.IGNORING_EXTRA_FIELDS;
 import static net.javacrumbs.jsonunit.core.Option.IGNORING_VALUES;
 import static net.javacrumbs.jsonunit.core.Option.TREATING_NULL_AS_ABSENT;
+import static net.javacrumbs.jsonunit.test.base.JsonTestUtils.failIfNoException;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -798,11 +799,6 @@ public abstract class AbstractJsonAssertTest {
         } catch (AssertionError e) {
             assertEquals("JSON documents are different:\nDifferent value found in node \"test\". Expected \"a\", got \"b\".\n", e.getMessage());
         }
-    }
-
-
-    protected void failIfNoException() {
-        fail("Exception expected");
     }
 
     protected abstract Object readValue(String value);

--- a/tests/test-base/src/main/java/net/javacrumbs/jsonunit/test/base/AbstractJsonAssertTest.java
+++ b/tests/test-base/src/main/java/net/javacrumbs/jsonunit/test/base/AbstractJsonAssertTest.java
@@ -670,12 +670,7 @@ public abstract class AbstractJsonAssertTest {
     @Test
     public void shouldIgnoreValuesInArray() {
         JsonAssert.setOptions(IGNORING_VALUES);
-        try {
-            assertJsonEquals("{\"test\":[{\"a\":1},{\"b\":2},{\"c\":3}]}", "{\"test\":[{\"a\":3},{\"b\":2},{\"c\":1}]}");
-        } catch (AssertionError e) {
-            assertEquals("JSON documents are different:\n" +
-                "Different value found in node \"test[1].b\". Expected '2', got '\"2\"'.\n", e.getMessage());
-        }
+        assertJsonEquals("{\"test\":[{\"a\":1},{\"b\":2},{\"c\":3}]}", "{\"test\":[{\"a\":3},{\"b\":2},{\"c\":1}]}");
     }
 
     @Test

--- a/tests/test-base/src/main/java/net/javacrumbs/jsonunit/test/base/AbstractJsonFluentAssertTest.java
+++ b/tests/test-base/src/main/java/net/javacrumbs/jsonunit/test/base/AbstractJsonFluentAssertTest.java
@@ -28,6 +28,7 @@ import static net.javacrumbs.jsonunit.JsonMatchers.jsonPartMatches;
 import static net.javacrumbs.jsonunit.core.Option.IGNORING_EXTRA_FIELDS;
 import static net.javacrumbs.jsonunit.core.Option.TREATING_NULL_AS_ABSENT;
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
+import static net.javacrumbs.jsonunit.test.base.JsonTestUtils.failIfNoException;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.everyItem;
 import static org.hamcrest.CoreMatchers.hasItem;
@@ -45,7 +46,7 @@ public abstract class AbstractJsonFluentAssertTest {
     public void testAssertString() {
         try {
             assertThatJson("{\"test\":1}").isEqualTo("{\"test\":2}");
-            expectException();
+            failIfNoException();
         } catch (AssertionError e) {
             assertEquals("JSON documents are different:\nDifferent value found in node \"test\". Expected 2, got 1.\n", e.getMessage());
         }
@@ -55,7 +56,7 @@ public abstract class AbstractJsonFluentAssertTest {
     public void testAssertDifferentType() {
         try {
             assertThatJson("{\"test\":\"1\"}").node("test").isEqualTo("1");
-            expectException();
+            failIfNoException();
         } catch (AssertionError e) {
             assertEquals("JSON documents are different:\nDifferent value found in node \"test\". Expected '1', got '\"1\"'.\n", e.getMessage());
         }
@@ -65,7 +66,7 @@ public abstract class AbstractJsonFluentAssertTest {
     public void testAssertDifferentTypeInt() {
         try {
             assertThatJson("{\"test\":\"1\"}").node("test").isEqualTo(1);
-            expectException();
+            failIfNoException();
         } catch (AssertionError e) {
             assertEquals("JSON documents are different:\nDifferent value found in node \"test\". Expected '1', got '\"1\"'.\n", e.getMessage());
         }
@@ -99,7 +100,7 @@ public abstract class AbstractJsonFluentAssertTest {
     public void testAssertNode() {
         try {
             assertThatJson(readValue("{\"test\":1}")).isEqualTo(readValue("{\"test\":2}"));
-            expectException();
+            failIfNoException();
         } catch (AssertionError e) {
             assertEquals("JSON documents are different:\nDifferent value found in node \"test\". Expected 2, got 1.\n", e.getMessage());
         }
@@ -109,7 +110,7 @@ public abstract class AbstractJsonFluentAssertTest {
     public void testAssertNodeInExpectOnly() {
         try {
             assertThatJson("{\"test\":1}").isEqualTo(readValue("{\"test\":2}"));
-            expectException();
+            failIfNoException();
         } catch (AssertionError e) {
             assertEquals("JSON documents are different:\nDifferent value found in node \"test\". Expected 2, got 1.\n", e.getMessage());
         }
@@ -119,7 +120,7 @@ public abstract class AbstractJsonFluentAssertTest {
     public void testAssertReader() {
         try {
             assertThatJson(new StringReader("{\"test\":1}")).isEqualTo(new StringReader("{\"test\":2}"));
-            expectException();
+            failIfNoException();
         } catch (AssertionError e) {
             assertEquals("JSON documents are different:\nDifferent value found in node \"test\". Expected 2, got 1.\n", e.getMessage());
         }
@@ -159,7 +160,7 @@ public abstract class AbstractJsonFluentAssertTest {
     public void testNotEqualTo() {
         try {
             assertThatJson("{\"test\":1}").isNotEqualTo("{\"test\": 1}");
-            expectException();
+            failIfNoException();
         } catch (AssertionError e) {
             assertEquals("JSON is equal.", e.getMessage());
         }
@@ -174,7 +175,7 @@ public abstract class AbstractJsonFluentAssertTest {
     public void testDifferentStructure() {
         try {
             assertThatJson("{\"test\":1}").hasSameStructureAs("{\"test\":21, \"a\":true}");
-            expectException();
+            failIfNoException();
         } catch (AssertionError e) {
             assertEquals("JSON documents are different:\nDifferent keys found in node \"\". Expected [a, test], got [test]. Missing: \"a\" \n", e.getMessage());
         }
@@ -184,7 +185,7 @@ public abstract class AbstractJsonFluentAssertTest {
     public void testAssertPath() {
         try {
             assertThatJson("{\"test\":1}").node("test").isEqualTo("2");
-            expectException();
+            failIfNoException();
         } catch (AssertionError e) {
             assertEquals("JSON documents are different:\nDifferent value found in node \"test\". Expected 2, got 1.\n", e.getMessage());
         }
@@ -194,7 +195,7 @@ public abstract class AbstractJsonFluentAssertTest {
     public void testAssertPathArray() {
         try {
             assertThatJson("{\"root\":{\"test\":[1,2,3]}}").node("root.test[0]").isEqualTo(2);
-            expectException();
+            failIfNoException();
         } catch (AssertionError e) {
             assertEquals("JSON documents are different:\nDifferent value found in node \"root.test[0]\". Expected 2, got 1.\n", e.getMessage());
         }
@@ -210,7 +211,7 @@ public abstract class AbstractJsonFluentAssertTest {
     public void testLongPaths() {
         try {
             assertThatJson("{\"root\":{\"test\":1}}").node("root.test").isEqualTo("2");
-            expectException();
+            failIfNoException();
         } catch (AssertionError e) {
             assertEquals("JSON documents are different:\nDifferent value found in node \"root.test\". Expected 2, got 1.\n", e.getMessage());
         }
@@ -220,7 +221,7 @@ public abstract class AbstractJsonFluentAssertTest {
     public void testMoreNodes() {
         try {
             assertThatJson("{\"test1\":2, \"test2\":1}").node("test1").isEqualTo(2).node("test2").isEqualTo(2);
-            expectException();
+            failIfNoException();
         } catch (AssertionError e) {
             assertEquals("JSON documents are different:\nDifferent value found in node \"test2\". Expected 2, got 1.\n", e.getMessage());
         }
@@ -230,7 +231,7 @@ public abstract class AbstractJsonFluentAssertTest {
     public void testNodeAbsent() {
         try {
             assertThatJson("{\"test1\":2, \"test2\":1}").node("test2").isAbsent();
-            expectException();
+            failIfNoException();
         } catch (AssertionError e) {
             assertEquals("Node \"test2\" is present.", e.getMessage());
         }
@@ -245,7 +246,7 @@ public abstract class AbstractJsonFluentAssertTest {
     public void testNodePresent() {
         try {
             assertThatJson("{\"test1\":2, \"test2\":1}").node("test3").isPresent();
-            expectException();
+            failIfNoException();
         } catch (AssertionError e) {
             assertEquals("Node \"test3\" is missing.", e.getMessage());
         }
@@ -260,7 +261,7 @@ public abstract class AbstractJsonFluentAssertTest {
     public void testMessage() {
         try {
             assertThatJson("{\"test\":1}").as("Test is different").isEqualTo("{\"test\":2}");
-            expectException();
+            failIfNoException();
         } catch (AssertionError e) {
             assertEquals("[Test is different] JSON documents are different:\nDifferent value found in node \"test\". Expected 2, got 1.\n", e.getMessage());
         }
@@ -285,7 +286,7 @@ public abstract class AbstractJsonFluentAssertTest {
     public void isArrayShouldFailIfArrayDoesNotExist() {
         try {
             assertThatJson("{\"test\":1}").node("test2").isArray();
-            expectException();
+            failIfNoException();
         } catch (AssertionError e) {
             assertEquals("Node \"test2\" is missing.", e.getMessage());
         }
@@ -295,7 +296,7 @@ public abstract class AbstractJsonFluentAssertTest {
     public void isArrayShouldFailIfItIsNotArray() {
         try {
             assertThatJson("{\"test\":\"1\"}").node("test").isArray();
-            expectException();
+            failIfNoException();
         } catch (AssertionError e) {
             assertEquals("Node \"test\" is not an array. The actual value is '\"1\"'.", e.getMessage());
         }
@@ -305,7 +306,7 @@ public abstract class AbstractJsonFluentAssertTest {
     public void arrayOfLengthShouldFailOnIncorrectSize() {
         try {
             assertThatJson("{\"test\":[1,2,3]}").node("test").isArray().ofLength(2);
-            expectException();
+            failIfNoException();
         } catch (AssertionError e) {
             assertEquals("Node \"test\" length is 3, expected length is 2.", e.getMessage());
         }
@@ -335,7 +336,7 @@ public abstract class AbstractJsonFluentAssertTest {
     public void intValueShouldFailIfDoesNotMatch() {
         try {
             assertThatJson("{\"test\":1}").node("test").matches(equalTo(valueOf(2)));
-            expectException();
+            failIfNoException();
         } catch (AssertionError e) {
             assertEquals("Node \"test\" does not match.\nExpected: <2>\n     but: was <1>", e.getMessage());
         }
@@ -351,7 +352,7 @@ public abstract class AbstractJsonFluentAssertTest {
     public void floatValueShouldFailIfDoesNotMatch() {
         try {
             assertThatJson("{\"test\":1}").node("test").matches(equalTo(valueOf(2)));
-            expectException();
+            failIfNoException();
         } catch (AssertionError e) {
             assertEquals("Node \"test\" does not match.\nExpected: <2>\n     but: was <1>", e.getMessage());
         }
@@ -367,7 +368,7 @@ public abstract class AbstractJsonFluentAssertTest {
     public void booleanValueShouldFailIfDoesNotMatch() {
         try {
             assertThatJson("{\"test2\":true}").node("test2").matches(equalTo(false));
-            expectException();
+            failIfNoException();
         } catch (AssertionError e) {
             assertEquals("Node \"test2\" does not match.\nExpected: <false>\n     but: was <true>", e.getMessage());
         }
@@ -377,7 +378,7 @@ public abstract class AbstractJsonFluentAssertTest {
     public void missingValueShouldFail() {
         try {
             assertThatJson("{\"test2\":true}").node("test").matches(equalTo(false));
-            expectException();
+            failIfNoException();
         } catch (AssertionError e) {
             assertEquals("Node \"test\" is missing.", e.getMessage());
         }
@@ -392,7 +393,7 @@ public abstract class AbstractJsonFluentAssertTest {
     public void stringValueShouldFailIfDoesNotMatch() {
         try {
             assertThatJson("{\"test\":\"one\"}").node("test").matches(equalTo("two"));
-            expectException();
+            failIfNoException();
         } catch (AssertionError e) {
             assertEquals("Node \"test\" does not match.\nExpected: \"two\"\n     but: was \"one\"", e.getMessage());
         }
@@ -407,7 +408,7 @@ public abstract class AbstractJsonFluentAssertTest {
     public void nullValueShouldFailIfDoesNotMatch() {
         try {
             assertThatJson("{\"test\":\"one\"}").node("test").matches(equalTo(nullValue()));
-            expectException();
+            failIfNoException();
         } catch (AssertionError e) {
             assertEquals("Node \"test\" does not match.\nExpected: <null>\n     but: was \"one\"", e.getMessage());
         }
@@ -428,7 +429,7 @@ public abstract class AbstractJsonFluentAssertTest {
     public void arrayMatcherShouldFailIfNotFound() {
         try {
             assertThatJson("{\"test\":[1,2,3]}").node("test").matches(hasItem(4));
-            expectException();
+            failIfNoException();
         } catch (AssertionError e) {
             assertEquals("Node \"test\" does not match.\nExpected: a collection containing <4>\n" +
                 "     but: was <1>, was <2>, was <3>", e.getMessage());
@@ -449,7 +450,7 @@ public abstract class AbstractJsonFluentAssertTest {
     public void objectMatcherShouldFailIfNotFound() {
         try {
             assertThatJson("{\"test\":[{\"value\":1},{\"value\":2},{\"value\":3}]}").node("test").matches(hasItem(jsonPartEquals("value", 4)));
-            expectException();
+            failIfNoException();
         } catch (AssertionError e) {
             assertEquals("Node \"test\" does not match.\n" +
                 "Expected: a collection containing 4 in \"value\"\n" +
@@ -466,7 +467,7 @@ public abstract class AbstractJsonFluentAssertTest {
     public void isStringShouldFailIfItDoesNotExist() {
         try {
             assertThatJson("{\"test\":1}").node("test2").isString();
-            expectException();
+            failIfNoException();
         } catch (AssertionError e) {
             assertEquals("Node \"test2\" is missing.", e.getMessage());
         }
@@ -476,7 +477,7 @@ public abstract class AbstractJsonFluentAssertTest {
     public void isStringShouldFailIfItIsNotAString() {
         try {
             assertThatJson("{\"test\":1}").node("test").isString();
-            expectException();
+            failIfNoException();
         } catch (AssertionError e) {
             assertEquals("Node \"test\" is not a string. The actual value is '1'.", e.getMessage());
         }
@@ -486,7 +487,7 @@ public abstract class AbstractJsonFluentAssertTest {
     public void isStringEqualToShouldFailIfItIsNotAString() {
         try {
             assertThatJson("{\"test\":1}").node("test").isStringEqualTo("1");
-            expectException();
+            failIfNoException();
         } catch (AssertionError e) {
             assertEquals("Node \"test\" is not a string. The actual value is '1'.", e.getMessage());
         }
@@ -496,7 +497,7 @@ public abstract class AbstractJsonFluentAssertTest {
     public void isStringEqualToShouldFailIfItDiffers() {
         try {
             assertThatJson("{\"test\":\"2\"}").node("test").isStringEqualTo("1");
-            expectException();
+            failIfNoException();
         } catch (AssertionError e) {
             assertEquals("Node \"test\" is not equal to \"1\".", e.getMessage());
         }
@@ -511,7 +512,7 @@ public abstract class AbstractJsonFluentAssertTest {
     public void equalsShouldFailOnStringAndANumber() {
         try {
             assertThatJson("{\"test\":\"1\"}").node("test").isEqualTo("1");
-            expectException();
+            failIfNoException();
         } catch (AssertionError e) {
             assertEquals("JSON documents are different:\n" +
                 "Different value found in node \"test\". Expected '1', got '\"1\"'.\n", e.getMessage());
@@ -522,7 +523,7 @@ public abstract class AbstractJsonFluentAssertTest {
     public void isStringShouldFailOnNull() {
         try {
             assertThatJson("{\"test\":null}").node("test").isStringEqualTo("1");
-            expectException();
+            failIfNoException();
         } catch (AssertionError e) {
             assertEquals("Node \"test\" is not a string. The actual value is 'null'.", e.getMessage());
         }
@@ -547,7 +548,7 @@ public abstract class AbstractJsonFluentAssertTest {
     public void isObjectShouldFailOnBoolean() {
         try {
             assertThatJson("{\"test\":{\"a\":true}}").node("test.a").isObject();
-            expectException();
+            failIfNoException();
         } catch (AssertionError e) {
             assertEquals("Node \"test.a\" is not an object. The actual value is 'true'.", e.getMessage());
         }
@@ -557,7 +558,7 @@ public abstract class AbstractJsonFluentAssertTest {
     public void isObjectShouldFailOnMissing() {
         try {
             assertThatJson("{\"test\":{\"a\":true}}").node("test.b").isObject();
-            expectException();
+            failIfNoException();
         } catch (AssertionError e) {
             assertEquals("Node \"test.b\" is missing.", e.getMessage());
         }
@@ -612,7 +613,7 @@ public abstract class AbstractJsonFluentAssertTest {
     public void testNullAndAbsent() {
         try {
             assertThatJson("{\"test\":{\"a\":1, \"b\": null}}").isEqualTo("{\"test\":{\"a\":1}}");
-            expectException();
+            failIfNoException();
         } catch (AssertionError e) {
             assertEquals("JSON documents are different:\n" +
                 "Different keys found in node \"test\". Expected [a], got [a, b].  Extra: \"test.b\"\n", e.getMessage());
@@ -643,15 +644,11 @@ public abstract class AbstractJsonFluentAssertTest {
     public void shouldAcceptEscapedPathAndShowCorrectErrorMessage() {
         try {
             assertThatJson("{\"foo.bar\":\"boo\"}").node("foo\\.bar").isEqualTo("baz");
-            expectException();
+            failIfNoException();
         } catch (AssertionError e) {
             assertEquals("JSON documents are different:\n" +
                 "Different value found in node \"foo\\.bar\". Expected \"baz\", got \"boo\".\n", e.getMessage());
         }
-    }
-
-    private void expectException() {
-        fail("Exception expected");
     }
 
     protected abstract Object readValue(String value);

--- a/tests/test-base/src/main/java/net/javacrumbs/jsonunit/test/base/AbstractJsonFluentAssertTest.java
+++ b/tests/test-base/src/main/java/net/javacrumbs/jsonunit/test/base/AbstractJsonFluentAssertTest.java
@@ -16,7 +16,6 @@
 package net.javacrumbs.jsonunit.test.base;
 
 import net.javacrumbs.jsonunit.core.Option;
-import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import java.io.StringReader;
@@ -91,6 +90,7 @@ public abstract class AbstractJsonFluentAssertTest {
     public void testAssertToleranceFailure() {
         try {
             assertThatJson("{\"test\":1.1}").node("test").withTolerance(0.001).isEqualTo(1);
+            failIfNoException();
         } catch (AssertionError e) {
             assertEquals("JSON documents are different:\nDifferent value found in node \"test\". Expected 1, got 1.1, difference is 0.1, tolerance is 0.001\n", e.getMessage());
         }

--- a/tests/test-base/src/main/java/net/javacrumbs/jsonunit/test/base/AbstractJsonMatchersTest.java
+++ b/tests/test-base/src/main/java/net/javacrumbs/jsonunit/test/base/AbstractJsonMatchersTest.java
@@ -34,6 +34,7 @@ import static net.javacrumbs.jsonunit.JsonMatchers.jsonStringPartEquals;
 import static net.javacrumbs.jsonunit.core.Option.IGNORING_EXTRA_FIELDS;
 import static net.javacrumbs.jsonunit.core.Option.IGNORING_VALUES;
 import static net.javacrumbs.jsonunit.core.Option.TREATING_NULL_AS_ABSENT;
+import static net.javacrumbs.jsonunit.test.base.JsonTestUtils.failIfNoException;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
@@ -69,7 +70,7 @@ public abstract class AbstractJsonMatchersTest {
     public void jsonPartMatchesShouldReturnNiceException() {
         try {
             assertThat("{\"test\":1}", jsonPartMatches("test", is(valueOf(2))));
-            expectException();
+            failIfNoException();
         } catch (AssertionError e) {
             assertEquals("\nExpected: node \"test\" is <2>\n" +
                     "     but: was <1>", e.getMessage());
@@ -80,7 +81,7 @@ public abstract class AbstractJsonMatchersTest {
     public void jsonPartMatchesShouldFailOnMissing() {
         try {
             assertThat("{\"test\":1}", jsonPartMatches("test2", is(valueOf(2))));
-            expectException();
+            failIfNoException();
         } catch (AssertionError e) {
             assertEquals("\nExpected: node \"test2\" is <2>\n" +
                     "     but: Node \"test2\" is missing.", e.getMessage());
@@ -96,7 +97,7 @@ public abstract class AbstractJsonMatchersTest {
     public void jsonPartMatchesShouldReturnNiceExceptionForArray() {
         try {
             assertThat("{\"test\":[1, 2, 3]}", jsonPartMatches("test", hasItems(valueOf(1), valueOf(2), valueOf(4))));
-            expectException();
+            failIfNoException();
         } catch (AssertionError e) {
             assertEquals("\nExpected: node \"test\" (a collection containing <1> and a collection containing <2> and a collection containing <4>)\n" +
                     "     but: was <[1, 2, 3]>", e.getMessage());
@@ -107,7 +108,7 @@ public abstract class AbstractJsonMatchersTest {
     public void shouldNotFailOnEmptyInput() {
         try {
             assertThat("", jsonEquals("{\"test\":1}"));
-            expectException();
+            failIfNoException();
         } catch (AssertionError e) {
             assertEquals("\nExpected: {\"test\":1}\n" +
                     "     but: JSON documents are different:\n" +
@@ -152,7 +153,7 @@ public abstract class AbstractJsonMatchersTest {
     public void testAssertDifferentTypeInt() {
         try {
             assertThat("{\"test\":\"1\"}", jsonPartEquals("test", 1));
-            expectException();
+            failIfNoException();
         } catch (AssertionError e) {
             assertEquals("\n" +
                     "Expected: 1 in \"test\"\n" +
@@ -178,7 +179,7 @@ public abstract class AbstractJsonMatchersTest {
     public void testDifferentValue() {
         try {
             assertThat("{\"test\":1}", jsonEquals("{\n\"test\": 2\n}"));
-            expectException();
+            failIfNoException();
         } catch (AssertionError e) {
             assertEquals("\nExpected: {\n\"test\": 2\n}\n" +
                     "     but: JSON documents are different:\n" +
@@ -190,7 +191,7 @@ public abstract class AbstractJsonMatchersTest {
     public void testDifferentStructure() {
         try {
             assertThat("{\"test\":1}", jsonEquals("{\n\"test2\": 2\n}"));
-            expectException();
+            failIfNoException();
         } catch (AssertionError e) {
             assertEquals("\nExpected: {\n\"test2\": 2\n}\n" +
                     "     but: JSON documents are different:\n" +
@@ -202,7 +203,7 @@ public abstract class AbstractJsonMatchersTest {
     public void testDifferentPartValue() {
         try {
             assertThat("{\"test\":1}", jsonPartEquals("test", "2"));
-            expectException();
+            failIfNoException();
         } catch (AssertionError e) {
             assertEquals("\nExpected: 2 in \"test\"\n" +
                     "     but: JSON documents are different:\n" +
@@ -214,7 +215,7 @@ public abstract class AbstractJsonMatchersTest {
     public void testAbsent() {
         try {
             assertThat("{\"test\":1}", jsonNodeAbsent("test"));
-            expectException();
+            failIfNoException();
         } catch (AssertionError e) {
             assertEquals("\n" +
                     "Expected: Node \"test\" is absent.\n" +
@@ -231,7 +232,7 @@ public abstract class AbstractJsonMatchersTest {
     public void testPresent() {
         try {
             assertThat("{\"test\":1}", jsonNodePresent("test.a"));
-            expectException();
+            failIfNoException();
         } catch (AssertionError e) {
             assertEquals("\n" +
                     "Expected: Node \"test.a\" is present.\n" +
@@ -248,7 +249,7 @@ public abstract class AbstractJsonMatchersTest {
     public void testNullAndAbsent() throws IOException {
         try {
             assertThat("{\"test\":{\"a\":1, \"b\": null}}", jsonEquals("{\"test\":{\"a\":1}}"));
-            expectException();
+            failIfNoException();
         } catch (AssertionError e) {
             assertEquals("\n" +
                     "Expected: {\"test\":{\"a\":1}}\n" +
@@ -271,10 +272,6 @@ public abstract class AbstractJsonMatchersTest {
     @Test
     public void testJsonNode() throws IOException {
         assertThat(readValue("{\"test\":1}"), jsonEquals("{\"test\":1}"));
-    }
-
-    private void expectException() {
-        fail("Exception expected");
     }
 
     protected abstract Object readValue(String value);

--- a/tests/test-base/src/main/java/net/javacrumbs/jsonunit/test/base/JsonTestUtils.java
+++ b/tests/test-base/src/main/java/net/javacrumbs/jsonunit/test/base/JsonTestUtils.java
@@ -19,6 +19,8 @@ import com.google.gson.JsonParser;
 
 import java.io.IOException;
 
+import static org.junit.Assert.fail;
+
 public class JsonTestUtils {
 
     public static Object readByJackson2(String value) {
@@ -39,5 +41,9 @@ public class JsonTestUtils {
 
     public static Object readByGson(String value) {
         return new JsonParser().parse(value);
+    }
+
+    public static void failIfNoException() {
+        fail("Exception expected");
     }
 }

--- a/tests/test-base/src/test/java/net/javacrumbs/jsonunit/test/all/AllJsonAssertTest.java
+++ b/tests/test-base/src/test/java/net/javacrumbs/jsonunit/test/all/AllJsonAssertTest.java
@@ -28,11 +28,11 @@ import static net.javacrumbs.jsonunit.JsonAssert.assertJsonEquals;
 import static net.javacrumbs.jsonunit.JsonAssert.assertJsonStructureEquals;
 import static net.javacrumbs.jsonunit.JsonAssert.when;
 import static net.javacrumbs.jsonunit.core.Option.IGNORING_VALUES;
+import static net.javacrumbs.jsonunit.test.base.JsonTestUtils.failIfNoException;
 import static net.javacrumbs.jsonunit.test.base.JsonTestUtils.readByGson;
 import static net.javacrumbs.jsonunit.test.base.JsonTestUtils.readByJackson1;
 import static net.javacrumbs.jsonunit.test.base.JsonTestUtils.readByJackson2;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 
 public class AllJsonAssertTest extends AbstractJsonAssertTest {
 


### PR DESCRIPTION
1. I added some missing failure call if no exception are thrown or the contrary : removed one try/catch assertion never thrown.
2. I renamed _fail_ methods in tests : from `expectException` and `doFail` to `failIfNoException`.