### PR TITLE
Feature : allow to disable array size comparison

### DIFF
--- a/json-unit-core/src/main/java/net/javacrumbs/jsonunit/core/Option.java
+++ b/json-unit-core/src/main/java/net/javacrumbs/jsonunit/core/Option.java
@@ -42,6 +42,11 @@ public enum Option {
     COMPARING_ONLY_STRUCTURE,
 
     /**
+     * Ignores array size differences. Compares only first element if it exists.
+     */
+    IGNORING_ARRAY_SIZE,
+
+    /**
      * Ignores values but fails if value types are different.
      */
     IGNORING_VALUES

--- a/json-unit-core/src/main/java/net/javacrumbs/jsonunit/core/internal/Diff.java
+++ b/json-unit-core/src/main/java/net/javacrumbs/jsonunit/core/internal/Diff.java
@@ -37,6 +37,8 @@ import static java.util.Collections.emptySet;
 import static net.javacrumbs.jsonunit.core.Option.COMPARING_ONLY_STRUCTURE;
 import static net.javacrumbs.jsonunit.core.Option.IGNORING_EXTRA_FIELDS;
 import static net.javacrumbs.jsonunit.core.Option.IGNORING_VALUES;
+import static net.javacrumbs.jsonunit.core.Option.IGNORING_ARRAY_ORDER;
+import static net.javacrumbs.jsonunit.core.Option.IGNORING_ARRAY_SIZE;
 import static net.javacrumbs.jsonunit.core.internal.JsonUtils.convertToJson;
 import static net.javacrumbs.jsonunit.core.internal.JsonUtils.getNode;
 import static net.javacrumbs.jsonunit.core.internal.JsonUtils.quoteIfNeeded;
@@ -290,12 +292,12 @@ public class Diff {
     private void compareArrayNodes(Node expectedNode, Node actualNode, String path) {
         List<Node> expectedElements = asList(expectedNode.arrayElements());
         List<Node> actualElements = asList(actualNode.arrayElements());
-        if (expectedElements.size() != actualElements.size()) {
+        if (!hasOption(IGNORING_ARRAY_SIZE) && expectedElements.size() != actualElements.size()) {
             structureDifferenceFound("Array \"%s\" has different length. Expected %d, got %d.", path, expectedElements.size(), actualElements.size());
         }
         List<Node> extraValues = new ArrayList<Node>();
         List<Node> missingValues = new ArrayList<Node>(expectedElements);
-        if (hasOption(Option.IGNORING_ARRAY_ORDER)) {
+        if (hasOption(IGNORING_ARRAY_ORDER)) {
             for (Node actual : actualElements) {
                 int index = indexOf(missingValues, actual);
                 if (index != -1) {
@@ -310,7 +312,11 @@ public class Diff {
             }
 
         } else {
-            for (int i = 0; i < Math.min(expectedElements.size(), actualElements.size()); i++) {
+            int elementsToCompare = Math.min(expectedElements.size(), actualElements.size());
+            if (hasOption(IGNORING_ARRAY_SIZE)) {
+                elementsToCompare = Math.min(elementsToCompare, 1);
+            }
+            for (int i = 0; i < elementsToCompare; i++) {
                 compareNodes(expectedElements.get(i), actualElements.get(i), getArrayPath(path, i));
             }
         }

--- a/tests/test-base/src/main/java/net/javacrumbs/jsonunit/test/base/AbstractJsonAssertTest.java
+++ b/tests/test-base/src/main/java/net/javacrumbs/jsonunit/test/base/AbstractJsonAssertTest.java
@@ -32,10 +32,7 @@ import static net.javacrumbs.jsonunit.JsonAssert.assertJsonPartNotEquals;
 import static net.javacrumbs.jsonunit.JsonAssert.assertJsonPartStructureEquals;
 import static net.javacrumbs.jsonunit.JsonAssert.assertJsonStructureEquals;
 import static net.javacrumbs.jsonunit.JsonAssert.when;
-import static net.javacrumbs.jsonunit.core.Option.IGNORING_ARRAY_ORDER;
-import static net.javacrumbs.jsonunit.core.Option.IGNORING_EXTRA_FIELDS;
-import static net.javacrumbs.jsonunit.core.Option.IGNORING_VALUES;
-import static net.javacrumbs.jsonunit.core.Option.TREATING_NULL_AS_ABSENT;
+import static net.javacrumbs.jsonunit.core.Option.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -768,6 +765,42 @@ public abstract class AbstractJsonAssertTest {
     @Test
     public void strictStructureEqualsShouldPassOnDifferentValue() {
         assertJsonEquals("{\"test\": \"4\"}", "{\"test\": \"3\"}", when(Option.IGNORING_VALUES));
+    }
+
+    @Test
+    public void shouldNotAssertArraySizeWithEmptyArrays() {
+        assertJsonEquals("{\"test\":[]}", "{\"test\":[]}", when(IGNORING_ARRAY_SIZE));
+    }
+
+    @Test
+    public void shouldNotAssertArraySizeWithExpectedArrayEmpty() {
+        assertJsonEquals("{\"test\":[]}", "{\"test\":[\"a\"]}", when(IGNORING_ARRAY_SIZE));
+    }
+
+    @Test
+    public void shouldNotAssertArraySizeWithActualArrayEmpty() {
+        assertJsonEquals("{\"test\":[\"a\"]}", "{\"test\":[]}", when(IGNORING_ARRAY_SIZE));
+    }
+
+    @Test
+    public void shouldNotAssertArraySize() {
+        assertJsonEquals("{\"test\":[\"a\",\"b\",\"c\"]}", "{\"test\":[\"a\"]}", when(IGNORING_ARRAY_SIZE));
+    }
+
+    @Test
+    public void shouldCompareOnlyFirstElement() {
+        assertJsonEquals("{\"test\":[{\"a\":1},{\"b\":2}]}", "{\"test\":[{\"a\":1},{\"c\":3},{\"b\":2}]}", when(IGNORING_ARRAY_SIZE));
+    }
+
+    @Test
+    public void shouldFailIfFirstElementIsDifferent() {
+        try {
+            assertJsonEquals("{\"test\":[{\"a\":1},{\"b\":2}]}", "{\"test\":[{\"b\":1},{\"a\":2}]}", when(IGNORING_ARRAY_SIZE));
+            failIfNoException();
+        } catch (AssertionError e) {
+            assertEquals("JSON documents are different:\n" +
+                    "Different keys found in node \"test[0]\". Expected [a], got [b]. Missing: \"test[0].a\" Extra: \"test[0].b\"\n", e.getMessage());
+        }
     }
 
     @Test


### PR DESCRIPTION
In this case, only first element is compared.

This is particularly desirable in conjunction with `IGNORING_VALUES` because you know that every object in the array are of the same structure.