### PR TITLE
Support for negative indexing into arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,13 @@ assertThatJson("{\"test1\":2, \"test2\":1}")
     .node("test1").isEqualTo(2)
     .node("test2").isEqualTo(2);
 
-assertThatJson("{\"root\":{\"test\":[1,2,3}}")
+// compare node indexed from start of array
+assertThatJson("{\"root\":{\"test\":[1,2,3]}}")
     .node("root.test[0]").isEqualTo(1);
+
+// compare node indexed from end of array
+assertThatJson("{\"root\":{\"test\":[1,2,3]}}")
+    .node("root.test[-1]").isEqualTo(3);
 
 // compares only the structure
 assertThatJson("{\"test\":1}")

--- a/json-unit-core/src/main/java/net/javacrumbs/jsonunit/core/internal/JsonUtils.java
+++ b/json-unit-core/src/main/java/net/javacrumbs/jsonunit/core/internal/JsonUtils.java
@@ -19,6 +19,7 @@ package net.javacrumbs.jsonunit.core.internal;
 import net.javacrumbs.jsonunit.core.Configuration;
 import net.javacrumbs.jsonunit.core.Option;
 
+import java.util.Iterator;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -27,7 +28,7 @@ import java.util.regex.Pattern;
  */
 public class JsonUtils {
 
-    private static final Pattern arrayPattern = Pattern.compile("(.*)\\[(\\d+)\\]");
+    private static final Pattern arrayPattern = Pattern.compile("(.*)\\[(-?\\d+)\\]");
 
     /**
      * We need to ignore "\." when splitting path.
@@ -94,7 +95,12 @@ public class JsonUtils {
             if (matcher.group(1).length() != 0) {
                 startNode = startNode.get(matcher.group(1));
             }
-            startNode = startNode.element(Integer.valueOf(matcher.group(2)));
+
+            int index = Integer.valueOf(matcher.group(2));
+            if(index<0) {
+                for(Iterator<Node> i = startNode.arrayElements();i.hasNext();i.next(), ++index);
+            }
+            startNode = startNode.element(index);
         }
         return startNode;
     }

--- a/json-unit-core/src/test/java/net/javacrumbs/jsonunit/core/internal/JsonUtilsTest.java
+++ b/json-unit-core/src/test/java/net/javacrumbs/jsonunit/core/internal/JsonUtilsTest.java
@@ -96,6 +96,13 @@ public class JsonUtilsTest {
     }
 
     @Test
+    public void testGetStartNodeArraysNegated() throws IOException {
+        Node startNode = getNode(mapper.readTree("{\"test\":{\"values\":[1,2,3,4]}}"), "test.values[-1]");
+        System.out.println(startNode);
+        assertEquals(4, startNode.decimalValue().intValue());
+    }
+
+    @Test
     public void testGetStartNodeArrays2() throws IOException {
         Node startNode = getNode(mapper.readTree("{\"test\":[{\"values\":[1,2]}, {\"values\":[3,4]}]}"), "test[1].values[1]");
         assertEquals(4, startNode.decimalValue().intValue());


### PR DESCRIPTION
I've got some cases where I need to assert about the final element in an array, irrespective of the array length. Negative indexing seemed the obvious solution.