### PR TITLE
Source for actual and expected json has been added to DifferenceListe…

### DIFF
--- a/json-unit-core/src/main/java/net/javacrumbs/jsonunit/core/Configuration.java
+++ b/json-unit-core/src/main/java/net/javacrumbs/jsonunit/core/Configuration.java
@@ -34,7 +34,7 @@ import static java.util.Arrays.asList;
 public class Configuration {
     private static final DifferenceListener DUMMY_LISTENER = new DifferenceListener() {
         @Override
-        public void diff(Difference difference) {
+        public void diff(Difference difference, Object actualSource, Object expectedSource) {
 
         }
     };

--- a/json-unit-core/src/main/java/net/javacrumbs/jsonunit/core/Configuration.java
+++ b/json-unit-core/src/main/java/net/javacrumbs/jsonunit/core/Configuration.java
@@ -17,6 +17,7 @@ package net.javacrumbs.jsonunit.core;
 
 import net.javacrumbs.jsonunit.core.internal.Options;
 import net.javacrumbs.jsonunit.core.listener.Difference;
+import net.javacrumbs.jsonunit.core.listener.DifferenceContext;
 import net.javacrumbs.jsonunit.core.listener.DifferenceListener;
 import org.hamcrest.Matcher;
 
@@ -34,7 +35,7 @@ import static java.util.Arrays.asList;
 public class Configuration {
     private static final DifferenceListener DUMMY_LISTENER = new DifferenceListener() {
         @Override
-        public void diff(Difference difference, Object actualSource, Object expectedSource) {
+        public void diff(Difference difference, DifferenceContext context) {
 
         }
     };

--- a/json-unit-core/src/main/java/net/javacrumbs/jsonunit/core/internal/Diff.java
+++ b/json-unit-core/src/main/java/net/javacrumbs/jsonunit/core/internal/Diff.java
@@ -44,6 +44,7 @@ import static net.javacrumbs.jsonunit.core.Option.IGNORING_EXTRA_ARRAY_ITEMS;
 import static net.javacrumbs.jsonunit.core.Option.IGNORING_EXTRA_FIELDS;
 import static net.javacrumbs.jsonunit.core.Option.IGNORING_VALUES;
 import static net.javacrumbs.jsonunit.core.internal.ClassUtils.isClassPresent;
+import static net.javacrumbs.jsonunit.core.internal.DifferenceContextImpl.differenceContext;
 import static net.javacrumbs.jsonunit.core.internal.JsonUnitLogger.NULL_LOGGER;
 import static net.javacrumbs.jsonunit.core.internal.JsonUtils.convertToJson;
 import static net.javacrumbs.jsonunit.core.internal.JsonUtils.quoteIfNeeded;
@@ -159,7 +160,8 @@ public class Diff {
     }
 
     private void reportDifference(Difference difference) {
-        configuration.getDifferenceListener().diff(difference, actualRoot, expectedRoot);
+        configuration.getDifferenceListener().diff(difference,
+                differenceContext(configuration, actualRoot, expectedRoot));
     }
 
     private void removePathsToBeIgnored(Path path, Set<String> extraKeys) {

--- a/json-unit-core/src/main/java/net/javacrumbs/jsonunit/core/internal/Diff.java
+++ b/json-unit-core/src/main/java/net/javacrumbs/jsonunit/core/internal/Diff.java
@@ -116,9 +116,7 @@ public class Diff {
     /**
      * Compares object nodes.
      *
-     * @param expected
-     * @param actual
-     * @param path
+     * @param context
      */
     private void compareObjectNodes(Context context) {
         Node expected = context.getExpectedNode();
@@ -161,7 +159,7 @@ public class Diff {
     }
 
     private void reportDifference(Difference difference) {
-        configuration.getDifferenceListener().diff(difference);
+        configuration.getDifferenceListener().diff(difference, actualRoot, expectedRoot);
     }
 
     private void removePathsToBeIgnored(Path path, Set<String> extraKeys) {
@@ -246,9 +244,7 @@ public class Diff {
     /**
      * Compares two nodes.
      *
-     * @param expectedNode
-     * @param actualNode
-     * @param fieldPath
+     * @param context
      */
     private void compareNodes(Context context) {
         if (shouldIgnorePath(context.getActualPath())) {

--- a/json-unit-core/src/main/java/net/javacrumbs/jsonunit/core/internal/DifferenceContextImpl.java
+++ b/json-unit-core/src/main/java/net/javacrumbs/jsonunit/core/internal/DifferenceContextImpl.java
@@ -1,0 +1,37 @@
+package net.javacrumbs.jsonunit.core.internal;
+
+import net.javacrumbs.jsonunit.core.Configuration;
+import net.javacrumbs.jsonunit.core.listener.DifferenceContext;
+
+public class DifferenceContextImpl implements DifferenceContext {
+
+    private final Configuration configuration;
+    private final Object actualSource;
+    private final Object expectedSource;
+
+    private DifferenceContextImpl(Configuration configuration, Object actualSource, Object expectedSource) {
+        this.configuration = configuration;
+        this.actualSource = actualSource;
+        this.expectedSource = expectedSource;
+    }
+
+
+    static DifferenceContextImpl differenceContext(Configuration configuration, Object actualSource, Object expectedSource) {
+        return new DifferenceContextImpl(configuration, actualSource, expectedSource);
+    }
+
+    @Override
+    public Configuration getConfiguration() {
+        return configuration;
+    }
+
+    @Override
+    public Object getActualSource() {
+        return actualSource;
+    }
+
+    @Override
+    public Object getExpectedSource() {
+        return expectedSource;
+    }
+}

--- a/json-unit-core/src/main/java/net/javacrumbs/jsonunit/core/internal/DifferenceImpl.java
+++ b/json-unit-core/src/main/java/net/javacrumbs/jsonunit/core/internal/DifferenceImpl.java
@@ -1,6 +1,5 @@
 package net.javacrumbs.jsonunit.core.internal;
 
-import net.javacrumbs.jsonunit.core.Configuration;
 import net.javacrumbs.jsonunit.core.listener.Difference;
 
 class DifferenceImpl implements Difference {
@@ -32,11 +31,6 @@ class DifferenceImpl implements Difference {
     public Object getExpected() {
         Node expectedNode = context.getExpectedNode();
         return expectedNode != null && !expectedNode.isMissingNode() ? expectedNode.getValue() : null;
-    }
-
-    @Override
-    public Configuration getConfiguration() {
-        return context.getConfiguration();
     }
 
     @Override

--- a/json-unit-core/src/main/java/net/javacrumbs/jsonunit/core/listener/Difference.java
+++ b/json-unit-core/src/main/java/net/javacrumbs/jsonunit/core/listener/Difference.java
@@ -1,7 +1,5 @@
 package net.javacrumbs.jsonunit.core.listener;
 
-import net.javacrumbs.jsonunit.core.Configuration;
-
 /**
  * Describes differences between documents.
  */
@@ -33,9 +31,4 @@ public interface Difference {
      * Type of the difference
      */
     Type getType();
-
-    /**
-     * Configuration used for comparison.
-     */
-    Configuration getConfiguration();
 }

--- a/json-unit-core/src/main/java/net/javacrumbs/jsonunit/core/listener/DifferenceContext.java
+++ b/json-unit-core/src/main/java/net/javacrumbs/jsonunit/core/listener/DifferenceContext.java
@@ -1,0 +1,22 @@
+package net.javacrumbs.jsonunit.core.listener;
+
+import net.javacrumbs.jsonunit.core.Configuration;
+
+public interface DifferenceContext {
+
+    /**
+     * Configuration used for comparison.
+     */
+    Configuration getConfiguration();
+
+    /**
+     * Actual source serialized as Map&lt;String, Object&gt; for objects, BigDecimal for numbers, ...
+     */
+    Object getActualSource();
+
+
+    /**
+     * Expected source serialized as Map&lt;String, Object&gt; for objects, BigDecimal for numbers, ...
+     */
+    Object getExpectedSource();
+}

--- a/json-unit-core/src/main/java/net/javacrumbs/jsonunit/core/listener/DifferenceListener.java
+++ b/json-unit-core/src/main/java/net/javacrumbs/jsonunit/core/listener/DifferenceListener.java
@@ -5,5 +5,5 @@ package net.javacrumbs.jsonunit.core.listener;
  * Can listen on differences between documents.
  */
 public interface DifferenceListener {
-    void diff(Difference difference, Object actualSource, Object expectedSource);
+    void diff(Difference difference, DifferenceContext context);
 }

--- a/json-unit-core/src/main/java/net/javacrumbs/jsonunit/core/listener/DifferenceListener.java
+++ b/json-unit-core/src/main/java/net/javacrumbs/jsonunit/core/listener/DifferenceListener.java
@@ -5,5 +5,5 @@ package net.javacrumbs.jsonunit.core.listener;
  * Can listen on differences between documents.
  */
 public interface DifferenceListener {
-    void diff(Difference difference);
+    void diff(Difference difference, Object actualSource, Object expectedSource);
 }

--- a/json-unit-core/src/test/java/net/javacrumbs/jsonunit/core/internal/DifferenceTest.java
+++ b/json-unit-core/src/test/java/net/javacrumbs/jsonunit/core/internal/DifferenceTest.java
@@ -194,7 +194,7 @@ public class DifferenceTest {
         private final List<Difference> differenceList = new ArrayList<Difference>();
 
         @Override
-        public void diff(Difference difference) {
+        public void diff(Difference difference, Object actualSource, Object expectedSource) {
             differenceList.add(difference);
         }
 

--- a/json-unit-core/src/test/java/net/javacrumbs/jsonunit/core/internal/DifferenceTest.java
+++ b/json-unit-core/src/test/java/net/javacrumbs/jsonunit/core/internal/DifferenceTest.java
@@ -3,6 +3,7 @@ package net.javacrumbs.jsonunit.core.internal;
 import net.javacrumbs.jsonunit.core.Configuration;
 import net.javacrumbs.jsonunit.core.Option;
 import net.javacrumbs.jsonunit.core.listener.Difference;
+import net.javacrumbs.jsonunit.core.listener.DifferenceContext;
 import net.javacrumbs.jsonunit.core.listener.DifferenceListener;
 import org.junit.Test;
 
@@ -185,6 +186,20 @@ public class DifferenceTest {
         assertThat((BigDecimal) listener.getDifferenceList().get(0).getExpected(), equalTo(valueOf(3)));
     }
 
+    @Test
+    public void shouldSeeActualSource() {
+        Diff diff = Diff.create("{\"test\": \"1\"}", "{}", "", "", commonConfig());
+        diff.similar();
+        assertThat(listener.getActualSource().toString(), equalTo("{}"));
+    }
+
+    @Test
+    public void shouldSeeExpectedSource() {
+        Diff diff = Diff.create("{\"test\": \"1\"}", "{}", "", "", commonConfig());
+        diff.similar();
+        assertThat(listener.getExpectedSource().toString(), equalTo("{\"test\":\"1\"}"));
+    }
+
 
     private Configuration commonConfig() {
         return Configuration.empty().withDifferenceListener(listener);
@@ -192,14 +207,26 @@ public class DifferenceTest {
 
     private static class RecordingDifferenceListener implements DifferenceListener {
         private final List<Difference> differenceList = new ArrayList<Difference>();
+        private Object actualSource;
+        private Object expectedSource;
 
         @Override
-        public void diff(Difference difference, Object actualSource, Object expectedSource) {
+        public void diff(Difference difference, DifferenceContext context) {
             differenceList.add(difference);
+            actualSource = context.getActualSource();
+            expectedSource = context.getExpectedSource();
         }
 
         public List<Difference> getDifferenceList() {
             return differenceList;
+        }
+
+        public Object getActualSource() {
+            return actualSource;
+        }
+
+        public Object getExpectedSource() {
+            return expectedSource;
         }
     }
 }

--- a/json-unit-spring/src/test/java/net/javacrumbs/jsonunit/spring/ExampleControllerTest.java
+++ b/json-unit-spring/src/test/java/net/javacrumbs/jsonunit/spring/ExampleControllerTest.java
@@ -17,6 +17,7 @@ package net.javacrumbs.jsonunit.spring;
 
 import net.javacrumbs.jsonunit.core.Option;
 import net.javacrumbs.jsonunit.core.listener.Difference;
+import net.javacrumbs.jsonunit.core.listener.DifferenceContext;
 import net.javacrumbs.jsonunit.core.listener.DifferenceListener;
 import org.junit.Before;
 import org.junit.Test;
@@ -75,7 +76,7 @@ public class ExampleControllerTest {
                     "Different value found in node \"result.string\", expected: <\"stringValue2\"> but was: <\"stringValue\">.\n",
                 e.getMessage());
 
-            verify(listener).diff(any(Difference.class), any(Object.class), any(Object.class));
+            verify(listener).diff(any(Difference.class), any(DifferenceContext.class));
         }
     }
 

--- a/json-unit-spring/src/test/java/net/javacrumbs/jsonunit/spring/ExampleControllerTest.java
+++ b/json-unit-spring/src/test/java/net/javacrumbs/jsonunit/spring/ExampleControllerTest.java
@@ -75,7 +75,7 @@ public class ExampleControllerTest {
                     "Different value found in node \"result.string\", expected: <\"stringValue2\"> but was: <\"stringValue\">.\n",
                 e.getMessage());
 
-            verify(listener).diff(any(Difference.class));
+            verify(listener).diff(any(Difference.class), any(Object.class), any(Object.class));
         }
     }
 

--- a/tests/test-base/src/main/java/net/javacrumbs/jsonunit/test/base/RecordingDifferenceListener.java
+++ b/tests/test-base/src/main/java/net/javacrumbs/jsonunit/test/base/RecordingDifferenceListener.java
@@ -16,6 +16,7 @@
 package net.javacrumbs.jsonunit.test.base;
 
 import net.javacrumbs.jsonunit.core.listener.Difference;
+import net.javacrumbs.jsonunit.core.listener.DifferenceContext;
 import net.javacrumbs.jsonunit.core.listener.DifferenceListener;
 
 import java.util.ArrayList;
@@ -25,7 +26,7 @@ public class RecordingDifferenceListener implements DifferenceListener {
     private final List<Difference> differenceList = new ArrayList<Difference>();
 
     @Override
-    public void diff(Difference difference, Object actualSource, Object expectedSource) {
+    public void diff(Difference difference, DifferenceContext context) {
         differenceList.add(difference);
     }
 

--- a/tests/test-base/src/main/java/net/javacrumbs/jsonunit/test/base/RecordingDifferenceListener.java
+++ b/tests/test-base/src/main/java/net/javacrumbs/jsonunit/test/base/RecordingDifferenceListener.java
@@ -25,7 +25,7 @@ public class RecordingDifferenceListener implements DifferenceListener {
     private final List<Difference> differenceList = new ArrayList<Difference>();
 
     @Override
-    public void diff(Difference difference) {
+    public void diff(Difference difference, Object actualSource, Object expectedSource) {
         differenceList.add(difference);
     }
 


### PR DESCRIPTION
Hi, Lucas

I haven't found the way to get actual and expected json source from current listener signature. 
The only way to do it is to set it in overrided class `.withDifferenceListener(listener.setActual(actual).setExpected(expected)));`
 Which doesn't look good... For our ease I suggest to add it into DifferenceListener. What do think about it?