### PR TITLE
Json-unit must have a dependency on hamcrest-core

### DIFF
--- a/json-unit-core/pom.xml
+++ b/json-unit-core/pom.xml
@@ -67,10 +67,12 @@
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-core</artifactId>
+            <version>${hamcrest.version}</version>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-library</artifactId>
+            <version>${hamcrest.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/json-unit-spring/pom.xml
+++ b/json-unit-spring/pom.xml
@@ -60,6 +60,7 @@
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-library</artifactId>
+            <version>${hamcrest.version}</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,7 @@
         <jackson2.version>2.9.6</jackson2.version>
         <moshi.version>1.6.0</moshi.version>
         <gson.version>2.8.5</gson.version>
+        <hamcrest.version>1.3</hamcrest.version>
         <johnzon.version>1.1.12</johnzon.version>
         <geronimo.json11.version>1.1</geronimo.json11.version>
         <jsonorg.version>20180130</jsonorg.version>
@@ -60,18 +61,6 @@
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-engine</artifactId>
                 <version>${junit-jupiter.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.hamcrest</groupId>
-                <artifactId>hamcrest-core</artifactId>
-                <version>1.3</version>
-                <optional>true</optional>
-            </dependency>
-            <dependency>
-                <groupId>org.hamcrest</groupId>
-                <artifactId>hamcrest-library</artifactId>
-                <version>1.3</version>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/tests/test-base/pom.xml
+++ b/tests/test-base/pom.xml
@@ -41,6 +41,7 @@
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-library</artifactId>
+            <version>${hamcrest.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Fixes https://github.com/lukas-krecan/JsonUnit/issues/193

Moves hamcrest-core dependency to whichever child module needs it