### PR TITLE
Fix Kotlin 'Inaccessible type' warning in when-path

### DIFF
--- a/json-unit-core/src/main/java/net/javacrumbs/jsonunit/core/ConfigurationWhen.java
+++ b/json-unit-core/src/main/java/net/javacrumbs/jsonunit/core/ConfigurationWhen.java
@@ -92,7 +92,7 @@ public class ConfigurationWhen {
         Configuration applyForPaths(Configuration configuration, PathsParam pathsParam);
     }
 
-    static class OptionsParam implements ApplicableForPath {
+    public static class OptionsParam implements ApplicableForPath {
         private final EnumSet<Option> options;
         private final boolean included;
 
@@ -107,7 +107,7 @@ public class ConfigurationWhen {
         }
     }
 
-    static class IgnoredParam implements ApplicableForPath {
+    public static class IgnoredParam implements ApplicableForPath {
         private IgnoredParam() {
         }
 


### PR DESCRIPTION
Hello. I have the following warning when using path options in Kotlin:

> Type ConfigurationWhen.OptionsParam! is inaccessible in this context due to: public/*package*/ open class OptionsParam : ConfigurationWhen.ApplicableForPath defined in net.javacrumbs.jsonunit.core.ConfigurationWhen

Can be fixed by using `@Suppress("INACCESSIBLE_TYPE")` on the client side or by making OptionsParam and IgnoredParam classes public. Unfortunately I haven't found another way to fix.