### PR TITLE
Fix Jackson2NodeFactory thread safety issue in usage of ServiceLoader.

### DIFF
--- a/json-unit-core/src/main/java/net/javacrumbs/jsonunit/core/internal/Jackson2NodeFactory.java
+++ b/json-unit-core/src/main/java/net/javacrumbs/jsonunit/core/internal/Jackson2NodeFactory.java
@@ -64,7 +64,7 @@ class Jackson2NodeFactory extends AbstractNodeFactory {
         return getMapperProvider().getObjectMapper(lenient);
     }
 
-    private Jackson2ObjectMapperProvider getMapperProvider() {
+    private synchronized Jackson2ObjectMapperProvider getMapperProvider() {
         Iterator<Jackson2ObjectMapperProvider> iterator = serviceLoader.iterator();
         if (iterator.hasNext()) {
             return iterator.next();


### PR DESCRIPTION
According to JavaDocs, the [`ServiceLoader`](https://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html) class is not thread-safe.  Quoting:

> Instances of this class are not safe for use by multiple concurrent threads.

In JsonUnit, the `Jackson2NodeFactory` uses `ServiceLoader` to bind with the Jackson implementation.  There is no locking around the `ServiceLoader` usage, so test suites that run multi-threaded are prone to intermittent failures from runtime exceptions.

This is an abridged stack trace from a multi-threaded test suite running 40 threads that surfaced the problem:

```
java.lang.ArrayIndexOutOfBoundsException: Index 2 out of bounds for length 2
	at java.base/java.lang.CompoundEnumeration.next(ClassLoader.java:3022)
	at java.base/java.lang.CompoundEnumeration.hasMoreElements(ClassLoader.java:3031)
	at java.base/java.util.ServiceLoader$LazyClassPathLookupIterator.nextProviderClass(ServiceLoader.java:1202)
	at java.base/java.util.ServiceLoader$LazyClassPathLookupIterator.hasNextService(ServiceLoader.java:1220)
	at java.base/java.util.ServiceLoader$LazyClassPathLookupIterator.hasNext(ServiceLoader.java:1264)
	at java.base/java.util.ServiceLoader$2.hasNext(ServiceLoader.java:1299)
	at java.base/java.util.ServiceLoader$3.hasNext(ServiceLoader.java:1384)
	at net.javacrumbs.jsonunit.core.internal.Jackson2NodeFactory.getMapperProvider(Jackson2NodeFactory.java:65)
	at net.javacrumbs.jsonunit.core.internal.Jackson2NodeFactory.getMapper(Jackson2NodeFactory.java:60)
	at net.javacrumbs.jsonunit.core.internal.Jackson2NodeFactory.readValue(Jackson2NodeFactory.java:51)
	at net.javacrumbs.jsonunit.core.internal.AbstractNodeFactory.readValue(AbstractNodeFactory.java:62)
	at net.javacrumbs.jsonunit.core.internal.AbstractNodeFactory.convertToNode(AbstractNodeFactory.java:32)
	at net.javacrumbs.jsonunit.core.internal.Converter.convertToNode(Converter.java:113)
	at net.javacrumbs.jsonunit.core.internal.JsonUtils.convertToJson(JsonUtils.java:56)
	at net.javacrumbs.jsonunit.core.internal.Diff.createInternal(Diff.java:113)
	at net.javacrumbs.jsonunit.JsonMatchers$JsonPartMatcher.doMatch(JsonMatchers.java:189)
	at net.javacrumbs.jsonunit.JsonMatchers$AbstractMatcher.matches(JsonMatchers.java:119)
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:12)
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:8)
        ...
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:124)
	at org.testng.internal.Invoker.invokeMethod(Invoker.java:583)
	at org.testng.internal.Invoker.invokeTestMethod(Invoker.java:719)
	at org.testng.internal.Invoker.invokeTestMethods(Invoker.java:989)
	at org.testng.internal.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:125)
	at org.testng.internal.TestMethodWorker.run(TestMethodWorker.java:109)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
```

I was able to reproduce this fairly regularly (approximately 1 in 10 test suite runs).  Then, I ran a local build with a patch to introduce locking around the `ServiceLoader` usage, and all runs consistently passed without throwing a runtime exception.
