### PR TITLE
Avoid to require same object instance on retrieval of differences

### DIFF
--- a/json-unit/src/main/java/net/javacrumbs/jsonunit/JsonMatchers.java
+++ b/json-unit/src/main/java/net/javacrumbs/jsonunit/JsonMatchers.java
@@ -29,7 +29,7 @@ import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 
 import java.math.BigDecimal;
-import java.util.IdentityHashMap;
+import java.util.HashMap;
 import java.util.Map;
 
 import static net.javacrumbs.jsonunit.core.internal.Diff.createInternal;
@@ -196,7 +196,7 @@ public class JsonMatchers {
         // One matcher can be used to match multiple array items. We need to persist diff description between doMatch() and
         // describeMismatch() method calls. While Hamcrest 1 called doMatch() and describeMismatch() one after each other
         // Hamcrest 2 calls doMatch() multiple times followed by multiple calls of describeMismatch()
-        private final Map<Object, String> differences = new IdentityHashMap<>();
+        private final Map<Object, String> differences = new HashMap<>();
 
         JsonPartMatcher(String path, Object expected) {
             super(path);

--- a/tests/test-base/src/test/java/net/javacrumbs/jsonunit/test/all/AllJsonMatchersTest.java
+++ b/tests/test-base/src/test/java/net/javacrumbs/jsonunit/test/all/AllJsonMatchersTest.java
@@ -17,6 +17,8 @@ package net.javacrumbs.jsonunit.test.all;
 
 import net.javacrumbs.jsonunit.test.base.AbstractJsonMatchersTest;
 import net.javacrumbs.jsonunit.test.base.JsonTestUtils;
+import org.hamcrest.Matcher;
+import org.hamcrest.StringDescription;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -26,6 +28,8 @@ import static net.javacrumbs.jsonunit.core.util.ResourceUtils.resource;
 import static net.javacrumbs.jsonunit.test.base.JsonTestUtils.readByJackson2;
 import static net.javacrumbs.jsonunit.test.base.JsonTestUtils.readByJsonOrg;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
 
 class AllJsonMatchersTest extends AbstractJsonMatchersTest {
     @Test
@@ -51,6 +55,18 @@ class AllJsonMatchersTest extends AbstractJsonMatchersTest {
     @Test
     void testEqualsUnicodeResource() throws Exception {
         assertThat("{\"face\":\"\uD83D\uDE10\"}", jsonEquals(resource("unicode.json")));
+    }
+
+    @Test
+    void testEqualsWithEqualItemButDifferentInstanceForDescribeMismatch() {
+        Matcher<Object> matcher = jsonEquals("{\"test\":1}");
+        String differentJson = "{\"test\":false}";
+        assertThat(matcher.matches("{\"test\":false}"), is(false));
+
+        String clonedJson = String.copyValueOf(differentJson.toCharArray());
+        StringDescription description = new StringDescription();
+        matcher.describeMismatch(clonedJson, description);
+        assertThat(description.toString(), containsString("Different value found in node"));
     }
 
     @Override


### PR DESCRIPTION
Hamcrest based Matcher are used in many different projects beside Hamcrest himself. These projects are not always well optimized like Hamcrest. Right now `JsonPartMatcher` uses an `IdentityHashMap` to cache pre-generatet difference description. `IdentityHashMap` does not compare object by calling `equals`. Instead the object instance ID is checked.  This requires, that `JsonPartMatcher::matches` and `JsonPartMatcher::describeMismatch` has to be called with the exact same object instance for the `actual` argument.

I replaced the `IdentityHashMap` with `HashMap` to allow a less strict comparison of object with the same content.