### PR TITLE
Enable writing BDD style assertions with JsonUnit

### DIFF
--- a/json-unit-assertj/src/main/java/net/javacrumbs/jsonunit/assertj/BDDJsonAssertions.java
+++ b/json-unit-assertj/src/main/java/net/javacrumbs/jsonunit/assertj/BDDJsonAssertions.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2009-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.javacrumbs.jsonunit.assertj;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import net.javacrumbs.jsonunit.assertj.JsonAssert.ConfigurableJsonAssert;
+import net.javacrumbs.jsonunit.assertj.JsonAssertions.JsonAssertionCallback;
+
+public class BDDJsonAssertions {
+
+	public static final BDDJsonAssertions and = new BDDJsonAssertions();
+
+	public static ConfigurableJsonAssert then(@Nullable Object actual) {
+		return JsonAssertions.assertThatJson(actual);
+	}
+	
+	public static ConfigurableJsonAssert then(@NotNull Object actual, @NotNull JsonAssertionCallback... callbacks) {
+		return JsonAssertions.assertThatJson(actual, callbacks);
+	}
+
+}


### PR DESCRIPTION
With these changes it is possible to write tests with jsonunit in Behavior Driven Design style. It is basically a little facade on the existing api adding the "then" part.

Similar approaches are done for example in AssertJ and Mockito to enable writing in this style.
Assertj: https://joel-costigliola.github.io/assertj/core/api/org/assertj/core/api/BDDAssertions.html
Mockito: https://javadoc.io/static/org.mockito/mockito-core/3.3.3/org/mockito/BDDMockito.html

A usage example combined with AssertJ would be:
````java
// GIVEN
HttpHeaders emptyHeaders = new HttpHeaders();
emptyHeaders.add(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.toString());

// WHEN
var response = restTemplate.exchange(//
		"/testEntities", //
		HttpMethod.GET, //
		new HttpEntity<>(emptyHeaders), //
		String.class);

// THEN
then(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
and.then(response.getBody())//
		.isObject()//
		.containsEntry("type", ConstraintViolationProblem.TYPE_VALUE)//
		.containsEntry("status", BigDecimal.valueOf(HttpStatus.BAD_REQUEST.value()))//
		.containsEntry("title", "Constraint Violation");