### PR TITLE
fix(sec): upgrade org.springframework:spring-web to 6.0.0

### DIFF
--- a/json-unit-spring/pom.xml
+++ b/json-unit-spring/pom.xml
@@ -6,7 +6,7 @@
         Spring Mock assertions
     </description>
     <properties>
-        <spring.version>5.3.25</spring.version>
+        <spring.version>6.0.0</spring.version>
         <kotlin.compiler.jvmTarget>1.8</kotlin.compiler.jvmTarget>
         <osgi.exportPackage>net.javacrumbs.jsonunit.spring</osgi.exportPackage>
     </properties>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.springframework:spring-web 5.3.25
- [CVE-2016-1000027](https://www.oscs1024.com/hd/CVE-2016-1000027)


### What did I do？
Upgrade org.springframework:spring-web from 5.3.25 to 6.0.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS