### PR TITLE
Make custom matcher regexp DOTALL

### DIFF
--- a/json-unit-core/src/main/java/net/javacrumbs/jsonunit/core/internal/Diff.java
+++ b/json-unit-core/src/main/java/net/javacrumbs/jsonunit/core/internal/Diff.java
@@ -69,7 +69,7 @@ public class Diff {
     private static final Pattern ANY_STRING_PLACEHOLDER = Pattern.compile("[$#]\\{json-unit.any-string\\}");
 
     private static final Pattern REGEX_PLACEHOLDER = Pattern.compile("[$#]\\{json-unit.regex\\}(.*)");
-    private static final Pattern MATCHER_PLACEHOLDER_PATTERN = Pattern.compile("[$#]\\{json-unit.matches:(.+?)\\}(.*)");
+    private static final Pattern MATCHER_PLACEHOLDER_PATTERN = Pattern.compile("[$#]\\{json-unit.matches:(.+?)\\}(.*)", Pattern.DOTALL);
 
     private static final JsonUnitLogger DEFAULT_DIFF_LOGGER = createLogger("net.javacrumbs.jsonunit.difference.diff");
     private static final JsonUnitLogger DEFAULT_VALUE_LOGGER = createLogger("net.javacrumbs.jsonunit.difference.values");


### PR DESCRIPTION
We have face an issue, that custom matcher fails comparison in case if input parameter contains line terminators.
To make `(.*)` match everything I suggest to update current regexp to be [DOTALL](https://docs.oracle.com/javase/7/docs/api/java/util/regex/Pattern.html#DOTALL)
if you need more appropriate example, please take a look [here](https://github.com/vividus-framework/vividus/pull/3743/files#diff-9a59b3b4964335232b07ebd7dd143c5ddf09c494b95fc33ffab477962ad3269dR234)