### PR TITLE
Add support for Jackson 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -738,6 +738,40 @@ public class Java8ObjectMapperProvider implements Jackson2ObjectMapperProvider {
 and register it in `META-INF/services/net.javacrumbs.jsonunit.providers.Jackson2ObjectMapperProvider`.
 See [this example](https://github.com/lukas-krecan/JsonUnit/commit/8dc7c884448c7373886dcf3b0eabfecf47c0710b).
 
+If you need to customize Jackson 3 Json Mapper, you can do using [SPI](https://docs.oracle.com/javase/tutorial/sound/SPI-intro.html).
+Implement `net.javacrumbs.jsonunit.providers.Jackson3JsonMapperProvider`.
+
+```java
+public class CustomObjectMapperProvider implements Jackson3JsonMapperProvider {
+    private final JsonMapper mapper;
+
+    private final JsonMapper lenientMapper;
+
+    public CustomObjectMapperProvider() {
+        mapper = JsonMapper.builder()
+                .enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS)
+                .enable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .build();
+
+        lenientMapper = JsonMapper.builder()
+                .enable(JsonReadFeature.ALLOW_UNQUOTED_PROPERTY_NAMES)
+                .enable(JsonReadFeature.ALLOW_JAVA_COMMENTS)
+                .enable(JsonReadFeature.ALLOW_SINGLE_QUOTES)
+                .enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS)
+                .enable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .build();
+    }
+
+    @Override
+    public JsonMapper getJsonMapper(boolean lenient) {
+        return lenient ? lenientMapper : mapper;
+    }
+}
+```
+
+and register it in `META-INF/services/net.javacrumbs.jsonunit.providers.Jackson3JsonMapperProvider`.
+See [this example](https://github.com/lukas-krecan/JsonUnit/commit/8dc7c884448c7373886dcf3b0eabfecf47c0710b).
+
 ## Logging
 
 Although the differences are printed out by the assert statement, sometimes you use JsonUnit with other libraries like
@@ -759,7 +793,7 @@ assertThatJson("{\"test\":-1}")
 
 JsonUnit is trying to cleverly match which JSON library to use. In case you need to change the default behavior, you can
 use `json-unit.libraries` system property. For example `-Djson-unit.libraries=jackson2,gson`
-or `System.setProperty("json-unit.libraries", "jackson2");`. Supported values are gson, json.org, moshi, jackson2
+or `System.setProperty("json-unit.libraries", "jackson2");`. Supported values are gson, json.org, moshi, jackson2, jackson3
 
 Licence
 -------

--- a/json-unit-core/pom.xml
+++ b/json-unit-core/pom.xml
@@ -8,6 +8,7 @@
     <properties>
         <osgi.importPackage>
             com.fasterxml.jackson.core;resolution:=optional,
+            tools.jackson.core;resolution:=optional,
             org.apache.johnzon.mapper;resolution:=optional,
             jakarta.json;resolution:=optional,
             com.google.gson;resolution:=optional,
@@ -42,6 +43,12 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>${jackson2.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>tools.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson3.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/json-unit-core/src/main/java/net/javacrumbs/jsonunit/core/internal/Converter.java
+++ b/json-unit-core/src/main/java/net/javacrumbs/jsonunit/core/internal/Converter.java
@@ -31,6 +31,9 @@ record Converter(List<NodeFactory> factories) {
     private static final boolean jackson2Present = isClassPresent("com.fasterxml.jackson.databind.ObjectMapper")
             && isClassPresent("com.fasterxml.jackson.core.JsonGenerator");
 
+    private static final boolean jackson3Present = isClassPresent("tools.jackson.databind.json.JsonMapper")
+            && isClassPresent("tools.jackson.core.JsonGenerator");
+
     private static final boolean gsonPresent = isClassPresent("com.google.gson.Gson");
 
     private static final boolean jsonOrgPresent = isClassPresent("org.json.JSONObject");
@@ -60,7 +63,7 @@ record Converter(List<NodeFactory> factories) {
 
         if (factories.isEmpty()) {
             throw new IllegalStateException(
-                    "Please add either json.org, Moshi, Jackson 2.x, Johnzon or Gson to the classpath");
+                    "Please add either json.org, Moshi, Jackson 2.x, Jackson 3.x, Johnzon or Gson to the classpath");
         }
         return new Converter(factories);
     }
@@ -73,6 +76,7 @@ record Converter(List<NodeFactory> factories) {
                 case "moshi" -> factories.add(new MoshiNodeFactory());
                 case "json.org" -> factories.add(new JsonOrgNodeFactory());
                 case "jackson2" -> factories.add(new Jackson2NodeFactory());
+                case "jackson3" -> factories.add(new Jackson3NodeFactory());
                 case "gson" -> factories.add(new GsonNodeFactory());
                 case "johnzon" -> factories.add(new JohnzonNodeFactory());
                 default -> throw new IllegalArgumentException("'" + factoryName + "' library name not recognized.");
@@ -97,6 +101,10 @@ record Converter(List<NodeFactory> factories) {
 
         if (gsonPresent) {
             factories.add(new GsonNodeFactory());
+        }
+
+        if (jackson3Present) {
+            factories.add(new Jackson3NodeFactory());
         }
 
         if (jackson2Present) {

--- a/json-unit-core/src/main/java/net/javacrumbs/jsonunit/core/internal/Jackson3NodeFactory.java
+++ b/json-unit-core/src/main/java/net/javacrumbs/jsonunit/core/internal/Jackson3NodeFactory.java
@@ -1,0 +1,240 @@
+/**
+ * Copyright 2009-2019 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.javacrumbs.jsonunit.core.internal;
+
+import static net.javacrumbs.jsonunit.core.internal.Utils.closeQuietly;
+
+import java.io.Reader;
+import java.math.BigDecimal;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.ServiceLoader;
+import net.javacrumbs.jsonunit.providers.Jackson3JsonMapperProvider;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.json.JsonReadFeature;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.cfg.JsonNodeFeature;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.node.NullNode;
+
+/**
+ * Deserializes node using Jackson 3
+ */
+class Jackson3NodeFactory extends AbstractNodeFactory {
+    private final ServiceLoader<Jackson3JsonMapperProvider> serviceLoader =
+            ServiceLoader.load(Jackson3JsonMapperProvider.class);
+
+    @Override
+    protected Node doConvertValue(Object source) {
+        if (source instanceof JsonNode) {
+            return newNode((JsonNode) source);
+        } else {
+            return newNode(getMapper(false).convertValue(source, JsonNode.class));
+        }
+    }
+
+    @Override
+    protected Node nullNode() {
+        return newNode(NullNode.getInstance());
+    }
+
+    @Override
+    protected Node readValue(Reader value, String label, boolean lenient) {
+        try {
+            return newNode(getMapper(lenient).readTree(value));
+        } catch (JacksonException e) {
+            throw newParseException(label, value, e);
+        } finally {
+            closeQuietly(value);
+        }
+    }
+
+    private JsonMapper getMapper(boolean lenient) {
+        return getMapperProvider().getJsonMapper(lenient);
+    }
+
+    private Jackson3JsonMapperProvider getMapperProvider() {
+        synchronized (serviceLoader) {
+            Iterator<Jackson3JsonMapperProvider> iterator = serviceLoader.iterator();
+            if (iterator.hasNext()) {
+                return iterator.next();
+            } else {
+                return DefaultJsonMapperProvider.INSTANCE;
+            }
+        }
+    }
+
+    private static Node newNode(JsonNode jsonNode) {
+        if (jsonNode != null && !jsonNode.isMissingNode()) {
+            return new Jackson3Node(jsonNode);
+        } else {
+            return Node.MISSING_NODE;
+        }
+    }
+
+    @Override
+    public boolean isPreferredFor(Object source) {
+        return source instanceof JsonNode;
+    }
+
+    static final class Jackson3Node extends AbstractNode {
+        private final JsonNode jsonNode;
+
+        Jackson3Node(JsonNode jsonNode) {
+            this.jsonNode = jsonNode;
+        }
+
+        @Override
+        public Node element(int index) {
+            return newNode(jsonNode.path(index));
+        }
+
+        @Override
+        public Iterator<KeyValue> fields() {
+            final Iterator<Map.Entry<String, JsonNode>> iterator =
+                    jsonNode.properties().iterator();
+            return new Iterator<>() {
+                @Override
+                public boolean hasNext() {
+                    return iterator.hasNext();
+                }
+
+                @Override
+                public void remove() {
+                    iterator.remove();
+                }
+
+                @Override
+                public KeyValue next() {
+                    Map.Entry<String, JsonNode> entry = iterator.next();
+                    return new KeyValue(entry.getKey(), newNode(entry.getValue()));
+                }
+            };
+        }
+
+        @Override
+        public Node get(String key) {
+            return newNode(jsonNode.get(key));
+        }
+
+        @Override
+        public boolean isMissingNode() {
+            return false;
+        }
+
+        @Override
+        public boolean isNull() {
+            return jsonNode.isNull();
+        }
+
+        @Override
+        public boolean isObject() {
+            return jsonNode.isObject();
+        }
+
+        @Override
+        public Iterator<Node> arrayElements() {
+            final Iterator<JsonNode> elements = jsonNode.values().iterator();
+            return new Iterator<>() {
+                @Override
+                public boolean hasNext() {
+                    return elements.hasNext();
+                }
+
+                @Override
+                public Node next() {
+                    return newNode(elements.next());
+                }
+
+                @Override
+                public void remove() {
+                    elements.remove();
+                }
+            };
+        }
+
+        @Override
+        public int size() {
+            return jsonNode.size();
+        }
+
+        @Override
+        public String asText() {
+            return jsonNode.asString();
+        }
+
+        @Override
+        public NodeType getNodeType() {
+            if (jsonNode.isObject()) {
+                return NodeType.OBJECT;
+            } else if (jsonNode.isArray()) {
+                return NodeType.ARRAY;
+            } else if (jsonNode.isString()) {
+                return NodeType.STRING;
+            } else if (jsonNode.isNumber()) {
+                return NodeType.NUMBER;
+            } else if (jsonNode.isBoolean()) {
+                return NodeType.BOOLEAN;
+            } else if (jsonNode.isNull()) {
+                return NodeType.NULL;
+            } else if (jsonNode.isBinary()) {
+                return NodeType.STRING;
+            } else {
+                throw new IllegalStateException("Unexpected node type " + jsonNode);
+            }
+        }
+
+        @Override
+        public BigDecimal decimalValue() {
+            return jsonNode.decimalValue();
+        }
+
+        @Override
+        public Boolean asBoolean() {
+            return jsonNode.asBoolean();
+        }
+
+        @Override
+        public String toString() {
+            return jsonNode.toString();
+        }
+    }
+
+    private static class DefaultJsonMapperProvider implements Jackson3JsonMapperProvider {
+        static final Jackson3JsonMapperProvider INSTANCE = new DefaultJsonMapperProvider();
+
+        private static final JsonMapper mapper = JsonMapper.builder()
+                .enable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS)
+                .enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS)
+                .disable(JsonNodeFeature.STRIP_TRAILING_BIGDECIMAL_ZEROES)
+                .findAndAddModules()
+                .build();
+        private static final JsonMapper lenientMapper = JsonMapper.builder()
+                .enable(JsonReadFeature.ALLOW_UNQUOTED_PROPERTY_NAMES)
+                .enable(JsonReadFeature.ALLOW_JAVA_COMMENTS)
+                .enable(JsonReadFeature.ALLOW_SINGLE_QUOTES)
+                .enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS)
+                .disable(JsonNodeFeature.STRIP_TRAILING_BIGDECIMAL_ZEROES)
+                .findAndAddModules()
+                .build();
+
+        @Override
+        public JsonMapper getJsonMapper(boolean lenient) {
+            return lenient ? lenientMapper : mapper;
+        }
+    }
+}

--- a/json-unit-core/src/main/java/net/javacrumbs/jsonunit/providers/Jackson3JsonMapperProvider.java
+++ b/json-unit-core/src/main/java/net/javacrumbs/jsonunit/providers/Jackson3JsonMapperProvider.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2009-2019 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.javacrumbs.jsonunit.providers;
+
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * Interface for customizing Jackson 3 JsonMapper. @see <a href="https://docs.oracle.com/javase/tutorial/sound/SPI-intro.html">SPI intro</a>
+ */
+public interface Jackson3JsonMapperProvider {
+    /**
+     * Provides JsonMapper
+     * @param lenient Lenient parsing is used for parsing the expected JSON value
+     * @return customized JsonMapper.
+     */
+    JsonMapper getJsonMapper(boolean lenient);
+}

--- a/json-unit-core/src/test/java/net/javacrumbs/jsonunit/core/internal/NodeFactoryTest.java
+++ b/json-unit-core/src/test/java/net/javacrumbs/jsonunit/core/internal/NodeFactoryTest.java
@@ -43,7 +43,11 @@ public class NodeFactoryTest {
     @Parameters
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][] {
-            {new JsonOrgNodeFactory()}, {new Jackson2NodeFactory()}, {new GsonNodeFactory()}, {new MoshiNodeFactory()},
+            {new JsonOrgNodeFactory()},
+            {new Jackson2NodeFactory()},
+            {new Jackson3NodeFactory()},
+            {new GsonNodeFactory()},
+            {new MoshiNodeFactory()},
         });
     }
 

--- a/json-unit-spring/pom.xml
+++ b/json-unit-spring/pom.xml
@@ -70,6 +70,12 @@
             <version>${jackson2.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>tools.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson3.version}</version>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>jakarta.servlet</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,7 @@
     <url>https://github.com/lukas-krecan/JsonUnit</url>
     <properties>
         <jackson2.version>2.20.0</jackson2.version>
+        <jackson3.version>3.0.0-rc10</jackson3.version>
         <moshi.version>1.15.2</moshi.version>
         <gson.version>2.13.2</gson.version>
         <hamcrest.version>3.0</hamcrest.version>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -16,6 +16,8 @@
         <module>test-kotlin</module>
         <module>test-jackson2</module>
         <module>test-jackson2-config</module>
+        <module>test-jackson3</module>
+        <module>test-jackson3-config</module>
         <module>test-johnzon</module>
         <module>test-gson</module>
         <module>test-jsonorg</module>

--- a/tests/test-base/pom.xml
+++ b/tests/test-base/pom.xml
@@ -58,6 +58,12 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>tools.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson3.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.apache.johnzon</groupId>
             <artifactId>johnzon-mapper</artifactId>
             <version>${johnzon.version}</version>

--- a/tests/test-base/src/main/java/net/javacrumbs/jsonunit/test/base/JsonTestUtils.java
+++ b/tests/test-base/src/main/java/net/javacrumbs/jsonunit/test/base/JsonTestUtils.java
@@ -34,6 +34,10 @@ public class JsonTestUtils {
         }
     }
 
+    public static Object readByJackson3(String value) {
+        return tools.jackson.databind.json.JsonMapper.shared().readTree(value);
+    }
+
     public static Object readByJohnzon(String value) {
         try (JsonReader reader = Json.createReader(new StringReader(value))) {
             return reader.read();

--- a/tests/test-base/src/test/java/net/javacrumbs/jsonunit/test/all/AllJsonAssertTest.java
+++ b/tests/test-base/src/test/java/net/javacrumbs/jsonunit/test/all/AllJsonAssertTest.java
@@ -139,6 +139,26 @@ class AllJsonAssertTest extends AbstractJsonAssertTest {
     }
 
     @Test
+    void shouldSerializeBasedOnAnnotationWithJackson3() {
+        try {
+            System.setProperty("json-unit.libraries", "jackson3");
+            assertJsonEquals("{\"bean\": {\"property\": \"value\"}}", new Jackson2Bean("value"));
+        } finally {
+            System.setProperty("json-unit.libraries", "");
+        }
+    }
+
+    @Test
+    void shouldSerializeBasedOnMethodAnnotationWithJackson3() {
+        try {
+            System.setProperty("json-unit.libraries", "jackson3");
+            assertJsonEquals("{\"property\": \"value\"}", new Jackson2IgnorePropertyBean("value"));
+        } finally {
+            System.setProperty("json-unit.libraries", "");
+        }
+    }
+
+    @Test
     void dotInPathFailure() {
         assertThatThrownBy(() -> assertJsonEquals(
                         "{\"root\":{\"test\":1, \".ignored\": 1}}", "{\"root\":{\"test\":1, \".ignored\": 2}}"))

--- a/tests/test-jackson3-config/pom.xml
+++ b/tests/test-jackson3-config/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>tests</artifactId>
+        <groupId>net.javacrumbs.json-unit</groupId>
+        <version>4.1.2-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>test-jackson3-config</artifactId>
+    <version>4.1.2-SNAPSHOT</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>net.javacrumbs.json-unit</groupId>
+            <artifactId>test-base</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>tools.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson3.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/tests/test-jackson3-config/src/test/java/net/javacrumbs/jsonunit/test/jackson3config/CustomObjectMapperProvider.java
+++ b/tests/test-jackson3-config/src/test/java/net/javacrumbs/jsonunit/test/jackson3config/CustomObjectMapperProvider.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2009-2019 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.javacrumbs.jsonunit.test.jackson3config;
+
+import net.javacrumbs.jsonunit.providers.Jackson3JsonMapperProvider;
+import tools.jackson.core.json.JsonReadFeature;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.cfg.DateTimeFeature;
+import tools.jackson.databind.json.JsonMapper;
+
+public class CustomObjectMapperProvider implements Jackson3JsonMapperProvider {
+    private final JsonMapper mapper;
+
+    private final JsonMapper lenientMapper;
+
+    public CustomObjectMapperProvider() {
+        mapper = JsonMapper.builder()
+                .enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS)
+                .enable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .build();
+
+        lenientMapper = JsonMapper.builder()
+                .enable(JsonReadFeature.ALLOW_UNQUOTED_PROPERTY_NAMES)
+                .enable(JsonReadFeature.ALLOW_JAVA_COMMENTS)
+                .enable(JsonReadFeature.ALLOW_SINGLE_QUOTES)
+                .enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS)
+                .enable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .build();
+    }
+
+    @Override
+    public JsonMapper getJsonMapper(boolean lenient) {
+        return lenient ? lenientMapper : mapper;
+    }
+}

--- a/tests/test-jackson3-config/src/test/java/net/javacrumbs/jsonunit/test/jackson3config/Jackson3ConfigTest.java
+++ b/tests/test-jackson3-config/src/test/java/net/javacrumbs/jsonunit/test/jackson3config/Jackson3ConfigTest.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2009-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.javacrumbs.jsonunit.test.jackson3config;
+
+import static net.javacrumbs.jsonunit.JsonAssert.assertJsonEquals;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+class Jackson3ConfigTest {
+
+    @Test
+    void testSerializeTime() {
+        assertThatJson(new Bean()).isEqualTo("{time:1547230320.000000000}");
+    }
+
+    @Test
+    void testSerializeTime2() {
+        assertThatJson(new Bean()).isEqualTo(new Bean());
+    }
+
+    @Test
+    void assertSame() {
+        String s = "{ \"a\": 0.0 }";
+        assertJsonEquals(s, s);
+    }
+
+    public static class Bean {
+        private final Instant time = Instant.parse("2019-01-11T18:12:00Z");
+
+        public Instant getTime() {
+            return time;
+        }
+    }
+}

--- a/tests/test-jackson3-config/src/test/resources/META-INF/services/net.javacrumbs.jsonunit.providers.Jackson3JsonMapperProvider
+++ b/tests/test-jackson3-config/src/test/resources/META-INF/services/net.javacrumbs.jsonunit.providers.Jackson3JsonMapperProvider
@@ -1,0 +1,1 @@
+net.javacrumbs.jsonunit.test.jackson3config.CustomObjectMapperProvider

--- a/tests/test-jackson3/pom.xml
+++ b/tests/test-jackson3/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>tests</artifactId>
+        <groupId>net.javacrumbs.json-unit</groupId>
+        <version>4.1.2-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>test-jackson3</artifactId>
+    <version>4.1.2-SNAPSHOT</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>net.javacrumbs.json-unit</groupId>
+            <artifactId>test-base</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>tools.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson3.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/tests/test-jackson3/src/test/java/net/javacrumbs/jsonunit/test/jackson3/Jackson3AssertJTest.java
+++ b/tests/test-jackson3/src/test/java/net/javacrumbs/jsonunit/test/jackson3/Jackson3AssertJTest.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2009-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.javacrumbs.jsonunit.test.jackson3;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.json;
+import static net.javacrumbs.jsonunit.test.base.JsonTestUtils.readByJackson3;
+
+import net.javacrumbs.jsonunit.test.base.AbstractAssertJTest;
+import org.junit.jupiter.api.Test;
+
+public class Jackson3AssertJTest extends AbstractAssertJTest {
+
+    @Test
+    void arrayContainsWithObjects() {
+        assertThatJson("{\"a\":[{\"b\": 1}, {\"c\": 1}]}")
+                .inPath("$.a")
+                .isArray()
+                .containsExactlyInAnyOrder(json(readValue("{\"c\": 1}")), json(readValue("{\"b\": 1}")));
+    }
+
+    @Override
+    protected Object readValue(String value) {
+        return readByJackson3(value);
+    }
+}

--- a/tests/test-jackson3/src/test/java/net/javacrumbs/jsonunit/test/jackson3/Jackson3FluentAssertTest.java
+++ b/tests/test-jackson3/src/test/java/net/javacrumbs/jsonunit/test/jackson3/Jackson3FluentAssertTest.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2009-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.javacrumbs.jsonunit.test.jackson3;
+
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
+
+import net.javacrumbs.jsonunit.test.base.AbstractJsonFluentAssertTest;
+import net.javacrumbs.jsonunit.test.base.JsonTestUtils;
+import org.junit.jupiter.api.Test;
+
+public class Jackson3FluentAssertTest extends AbstractJsonFluentAssertTest {
+    @Override
+    protected Object readValue(String value) {
+        return JsonTestUtils.readByJackson3(value);
+    }
+
+    @Test
+    void testOkWithLibrary() {
+        System.setProperty("json-unit.libraries", "jackson3");
+        try {
+            assertThatJson("{\"test\":1}").isEqualTo("{\"test\":1}");
+        } finally {
+            System.setProperty("json-unit.libraries", "");
+        }
+    }
+}

--- a/tests/test-jackson3/src/test/java/net/javacrumbs/jsonunit/test/jackson3/Jackson3JsonAssertTest.java
+++ b/tests/test-jackson3/src/test/java/net/javacrumbs/jsonunit/test/jackson3/Jackson3JsonAssertTest.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2009-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.javacrumbs.jsonunit.test.jackson3;
+
+import net.javacrumbs.jsonunit.test.base.AbstractJsonAssertTest;
+import net.javacrumbs.jsonunit.test.base.JsonTestUtils;
+
+public class Jackson3JsonAssertTest extends AbstractJsonAssertTest {
+
+    @Override
+    protected Object readValue(String value) {
+        return JsonTestUtils.readByJackson3(value);
+    }
+}

--- a/tests/test-jackson3/src/test/java/net/javacrumbs/jsonunit/test/jackson3/Jackson3JsonMatchersTest.java
+++ b/tests/test-jackson3/src/test/java/net/javacrumbs/jsonunit/test/jackson3/Jackson3JsonMatchersTest.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2009-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.javacrumbs.jsonunit.test.jackson3;
+
+import net.javacrumbs.jsonunit.test.base.AbstractJsonMatchersTest;
+import net.javacrumbs.jsonunit.test.base.JsonTestUtils;
+
+public class Jackson3JsonMatchersTest extends AbstractJsonMatchersTest {
+    @Override
+    protected Object readValue(String value) {
+        return JsonTestUtils.readByJackson3(value);
+    }
+}


### PR DESCRIPTION
Jackson 3 is going to be the new default for Spring Boot 4 and Spring Framework 7 is going to deprecate Jackson 2.x in favor of Jackson 3.x.

This PR adds support for Jackson 3.

