### PR TITLE
Fix JsonPath ignore matching for expected-only paths

### DIFF
--- a/json-unit-core/src/main/java/net/javacrumbs/jsonunit/core/internal/Diff.java
+++ b/json-unit-core/src/main/java/net/javacrumbs/jsonunit/core/internal/Diff.java
@@ -38,6 +38,7 @@ import static net.javacrumbs.jsonunit.core.internal.Node.KeyValue;
 import static net.javacrumbs.jsonunit.core.internal.Node.MISSING_NODE;
 import static net.javacrumbs.jsonunit.core.internal.Node.NodeType;
 import static net.javacrumbs.jsonunit.core.internal.Normalizer.toNormalizedString;
+import static net.javacrumbs.jsonunit.jsonpath.InternalJsonPathUtils.resolveJsonPaths;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -148,11 +149,12 @@ public class Diff {
             Path path,
             Configuration configuration,
             String differenceString) {
+        Configuration resolvedConfiguration = resolveJsonPaths(expected, actual, configuration);
         return new Diff(
                 convertToJson(quoteIfNeeded(expected), "expected", true),
                 convertToJson(actual, actualName, false),
                 path,
-                configuration,
+                resolvedConfiguration,
                 DEFAULT_DIFF_LOGGER,
                 DEFAULT_VALUE_LOGGER,
                 differenceString);

--- a/json-unit-core/src/main/java/net/javacrumbs/jsonunit/core/internal/PathMatcher.java
+++ b/json-unit-core/src/main/java/net/javacrumbs/jsonunit/core/internal/PathMatcher.java
@@ -67,7 +67,17 @@ abstract class PathMatcher {
     private static class ArrayWildcardMatcher extends PathMatcher {
         private final Pattern pattern;
 
+        // JsonPath-based ignores may keep the original "$" path when there is no concrete match.
+        // Compare against JsonUnit paths too, so "$.array[*].id" still matches "array[0].id".
+        private final @Nullable Pattern normalizedPattern;
+
         ArrayWildcardMatcher(String path) {
+            this.pattern = Pattern.compile(toRegex(path));
+            String normalizedPath = removeRootPrefix(path);
+            this.normalizedPattern = normalizedPath.equals(path) ? null : Pattern.compile(toRegex(normalizedPath));
+        }
+
+        private static String toRegex(String path) {
             StringBuilder regexp = new StringBuilder();
             int from = 0;
             int to;
@@ -79,12 +89,24 @@ abstract class PathMatcher {
             if (from < path.length()) {
                 regexp.append("\\Q").append(path.substring(from)).append("\\E");
             }
-            pattern = Pattern.compile(regexp.toString());
+            return regexp.toString();
+        }
+
+        private static String removeRootPrefix(String path) {
+            if (path.startsWith("$.")) {
+                return path.substring(2);
+            } else if (path.startsWith("$[")) {
+                return path.substring(1);
+            } else {
+                return path;
+            }
         }
 
         @Override
         boolean matches(String pathToMatch) {
-            return pattern.matcher(pathToMatch).matches();
+            return pattern.matcher(pathToMatch).matches()
+                    || (normalizedPattern != null
+                            && normalizedPattern.matcher(pathToMatch).matches());
         }
     }
 

--- a/json-unit-core/src/main/java/net/javacrumbs/jsonunit/jsonpath/InternalJsonPathUtils.java
+++ b/json-unit-core/src/main/java/net/javacrumbs/jsonunit/jsonpath/InternalJsonPathUtils.java
@@ -19,8 +19,10 @@ import static com.jayway.jsonpath.JsonPath.using;
 
 import com.jayway.jsonpath.Option;
 import com.jayway.jsonpath.PathNotFoundException;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Stream;
 import net.javacrumbs.jsonunit.core.Configuration;
 import net.javacrumbs.jsonunit.core.internal.JsonUtils;
@@ -33,10 +35,16 @@ public class InternalJsonPathUtils {
     private InternalJsonPathUtils() {}
 
     public static Configuration resolveJsonPaths(@Nullable Object json, Configuration configuration) {
-        Collection<String> pathsToBeIgnored = resolveJsonPaths(json, configuration.getPathsToBeIgnored());
+        return resolveJsonPaths(null, json, configuration);
+    }
+
+    public static Configuration resolveJsonPaths(
+            @Nullable Object expected, @Nullable Object actual, Configuration configuration) {
+        Collection<String> pathsToBeIgnored =
+                resolveJsonPaths(Arrays.asList(expected, actual), configuration.getPathsToBeIgnored());
         List<PathOption> pathOptions = configuration.getPathOptions().stream()
                 .map(po -> {
-                    List<String> newPoPaths = resolveJsonPaths(json, po.getPaths());
+                    List<String> newPoPaths = resolveJsonPaths(Arrays.asList(expected, actual), po.getPaths());
                     return po.withPaths(newPoPaths);
                 })
                 .toList();
@@ -44,7 +52,7 @@ public class InternalJsonPathUtils {
         return configuration.whenIgnoringPaths(pathsToBeIgnored).withPathOptions(pathOptions);
     }
 
-    private static List<String> resolveJsonPaths(@Nullable Object json, Collection<String> paths) {
+    private static List<String> resolveJsonPaths(List<@Nullable Object> jsons, Collection<String> paths) {
         com.jayway.jsonpath.Configuration conf = com.jayway.jsonpath.Configuration.builder()
                 .options(Option.AS_PATH_LIST, Option.SUPPRESS_EXCEPTIONS)
                 .build();
@@ -52,15 +60,18 @@ public class InternalJsonPathUtils {
         return paths.stream()
                 .flatMap(path -> {
                     if (path.startsWith("$")) {
-                        if (json == null) {
-                            return Stream.empty();
-                        }
-                        List<String> resolvedPaths = readValue(conf, json, path);
-                        return resolvedPaths.stream().map(InternalJsonPathUtils::fromBracketNotation);
+                        Stream<String> originalPath = Stream.of(path);
+                        Stream<String> resolvedPaths = jsons.stream()
+                                .filter(Objects::nonNull)
+                                .flatMap(json ->
+                                        InternalJsonPathUtils.<List<String>>readValue(conf, json, path).stream())
+                                .map(InternalJsonPathUtils::fromBracketNotation);
+                        return Stream.concat(originalPath, resolvedPaths);
                     } else {
                         return Stream.of(path);
                     }
                 })
+                .distinct()
                 .toList();
     }
 

--- a/tests/test-base/src/main/java/net/javacrumbs/jsonunit/test/base/AbstractAssertJTest.java
+++ b/tests/test-base/src/main/java/net/javacrumbs/jsonunit/test/base/AbstractAssertJTest.java
@@ -707,6 +707,45 @@ public abstract class AbstractAssertJTest {
     }
 
     @Test
+    void shouldIgnoreJsonPathMissingInActual() {
+        assertThatJson("{\"children\":[{\"name\":\"someName\"}]}")
+                .whenIgnoringPaths("$.children[*].id")
+                .isEqualTo("{\"children\":[{\"id\":\"ignored\",\"name\":\"someName\"}]}");
+    }
+
+    @Test
+    void shouldResolveIgnoredJsonPathFromExpected() {
+        assertThatJson(
+                        """
+                        {
+                          "fields": [
+                            {
+                              "name": "AA"
+                            },
+                            {
+                              "key": 2,
+                              "name": "AB"
+                            }
+                          ]
+                        }""")
+                .whenIgnoringPaths("$.fields[?(@.name=='AA')].key")
+                .isEqualTo(
+                        """
+                        {
+                          "fields": [
+                            {
+                              "key": 1,
+                              "name": "AA"
+                            },
+                            {
+                              "key": 2,
+                              "name": "AB"
+                            }
+                          ]
+                        }""");
+    }
+
+    @Test
     void arraySimpleIgnoringOrderNotEqualComparison() {
         assertThatJson("{\"a\":[{\"b\": 1}, {\"c\": 1}, {\"d\": 1}]}")
                 .when(Option.IGNORING_ARRAY_ORDER)


### PR DESCRIPTION
Resolve JsonPath-based path options against both expected and actual JSON, and keep the original JsonPath pattern so wildcard ignores can still match JsonUnit paths when no concrete path exists in actual.

Add AssertJ regression tests for ignored JsonPath fields missing from actual, including predicate-based JsonPath resolution from expected.